### PR TITLE
docs(phase-0): backfill 3 design artifacts + mandate going forward + postmortem

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -17,6 +17,30 @@ and HITL gates defined inline.
    adversary challenge), and `@task-breakdown` for atomic decomposition.
    For daemon work: verify async patterns and shared state implications.
 
+   **Mandatory workitem artifacts** (per the Phase-0 design alignment,
+   2026-05-02). Every workitem under `.workitems/<NXX>/<FYY>/` MUST
+   contain these files before any code task in the workitem moves to
+   `[x] done`:
+
+   | File                       | Purpose                                                          |
+   |----------------------------|------------------------------------------------------------------|
+   | `design.md`                | Overview, problem, dependencies, interfaces, DEs, OOS, risks      |
+   | `tasks.md`                 | T-NN list with the standard done-marker contract (`task-format.md`) |
+   | `user_stories.md`          | US-NN with explicit ACs                                          |
+   | `traceability.yaml`        | ACM nodes/edges, de_to_hld, ac_to_story, task_to_de              |
+   | **`functional-test-plan.md`** | FT-NNN scenarios, negative / boundary / integration / audit; regression risks; open questions |
+   | **`behavioural-test-plan.md`**  | BT-NNN persona scenarios, edge / misuse / recovery, collaboration breakdown, open questions |
+   | **`ontology-delta.yaml`**       | modules / classes / functions / constants / adr_decisions / tasks added by this feature |
+
+   The latter three are the foundational design assets. They MAY be
+   authored as a backfill within the same PR that ships the feature
+   code, but they MUST land before merge — no exceptions for "scaffold-
+   only" work. F21's workitem is the canonical template for all three.
+
+   See `docs/research/sdlc-shortcut-postmortem-phase0.md` for the
+   incident that surfaced this rule and the explicit decision to make
+   these artifacts mandatory.
+
    **Two-skill design (biz → sw)** — When `@biz-functional-design` has been
    run for a feature (presence of `functional-test-plan.md` in the workitem
    folder), `@design-pipeline` Stage 0 detects this and delegates to

--- a/.workitems/N02-hebrew-interpretation/F51-homograph-context-rules/behavioural-test-plan.md
+++ b/.workitems/N02-hebrew-interpretation/F51-homograph-context-rules/behavioural-test-plan.md
@@ -1,0 +1,116 @@
+<!-- Authored 2026-05-02 as Phase-0 design backfill; F51 was already merged in PR #29. -->
+
+# N02/F51 — Homograph Context-Rules: Behavioural Test Plan
+
+## Patterns Covered
+
+| Behaviour                                                    | Persona               | Risk                                          | Test    |
+|--------------------------------------------------------------|-----------------------|-----------------------------------------------|---------|
+| Student listens to a "כל אם" sentence with a possessive child | P01 (ל"ל student)    | hears "the girl" instead of "her child"       | BT-300  |
+| Maintainer extends trigger lexicon for a new possessor noun   | P11 (NLP maintainer)  | over-firing on metaphoric usage               | BT-301  |
+| Reviewer audits a rule-overridden token in F50 portal         | P08 (QA / teacher)    | invisible rule decision                       | BT-302  |
+| Pipeline encounters S1-style genuinely ambiguous sentence     | P01 + P08             | system commits to one of two valid readings   | BT-303  |
+| Gemma harness prompt called for hard case                     | P11                   | num_predict cap kills the response             | BT-304  |
+| F19 Nakdan REST returns a malformed response                  | P11                   | rule layer crashes downstream                  | BT-305  |
+
+## Scenarios
+
+- **BT-300** Student listens to "כל אם רוצה את הטוב ביותר לילדה"
+  on Economy.pdf-style content. Audio plays "le-yald-AH"
+  (with mappiq) — the "her child" reading. Behavioural log shows
+  `context_rule: possessive-mappiq fired, picked_index=3`.
+  Student understands the sentence as a generic statement about
+  every mother and her own child, not "to the girl" (which would
+  imply a specific identified girl).
+
+- **BT-301** Maintainer proposes adding `סבא` (grandfather) to
+  the trigger lexicon. PR review surfaces the question: does
+  "כל סבא רוצה X לבת" really fire mappiq? Reviewer adds a fixture
+  case AND a negative case (`כל סבא קונה לבת מתנה ביום הולדתה` —
+  could mean "to a granddaughter" not "to her granddaughter").
+  PR adjusts the case set; lexicon grows with caution.
+
+- **BT-302** Teacher reviewing a Bagrut page in F50 portal sees
+  a token where the rule fired. Tooltip shows ADR-038 reference,
+  the trigger lexicon match, and the picked index. Teacher
+  agrees the override is correct; no action needed. Behavioural:
+  audit trail enables silent verification, not just error
+  detection.
+
+- **BT-303** A page contains the user-flagged S1 sentence
+  ("האם הקריאה ספר לילדה" — genuinely ambiguous between mother
+  and whether). The deterministic rule does NOT fire (no possessor
+  trigger). Nakdan top-1 picks one reading. The Gemma harness
+  prompt (when wired in via the deferred OllamaHomographJudge)
+  would emit `verdict: "ambiguous"` per ADR-040 — surfacing both
+  readings to F50. Until that consumer ships, the cascade
+  silently picks one. Documented limitation; tracked by issue
+  #28 and the deferred judge.
+
+- **BT-304** Hard homograph case in production: F48 OCR reviewer
+  calls Gemma. With `num_predict` capped to default (no cap),
+  Gemma emits a 30-character JSON after ~3000 tokens of internal
+  reasoning. With `num_predict=256`, the same call returns an
+  empty string (Gemma killed mid-thought). Mitigation: F48
+  callers must NOT cap below ~6000; documented in
+  `_meta.yaml`.
+
+- **BT-305** F19 Nakdan REST returns a malformed JSON (vendor
+  outage / partial response). The vendor-boundary contract test
+  catches the shape change; cascade falls to the legacy-string
+  options path. F51 rule layer sees a degraded option list;
+  rule may not find mappiq variants; returns None; legacy
+  Nakdan top-1 wins. Audio still plays (degraded) — never
+  crashes.
+
+## Edge / Misuse / Recovery
+
+- **Edge: trigger word at end of sentence**. `כל אם רוצה
+  לילדה ספר טוב, כל אם.` — second `כל אם` is at the end. Rule
+  fires once (the regex finds the first match); first fragment
+  resolves correctly. Subsequent fragment also passes through
+  the chunker (F53) and may be rule-overridden again per its
+  own `apply_rule` call.
+- **Edge: focus word that is NOT a noun**. The rule only
+  inspects mappiq presence in the candidate list — it doesn't
+  validate that the focus is noun-shaped. If a verb candidate
+  happens to end in `ה`+mappiq (rare), the rule could fire.
+  Documented; not yet observed in fixture.
+- **Misuse: developer adds a regex wildcard to the trigger
+  lexicon** (e.g., `\bכל\s+\w+\b`). Architecture forbids;
+  reviewer rejects in PR. The conservative approach is the
+  point.
+- **Recovery: rule raises**. Should not happen — pure regex +
+  list iteration. If it does, F19 inference layer's caller
+  catches and falls through to top-1.
+
+## Collaboration Breakdown
+
+- **F19 maintainer changes Nakdan response shape** (PR #31
+  did exactly this — `task: nakdan` → `task: morph`). F51
+  consumes Nakdan options as either str or dict; `_apply_context_rules`
+  extracts the `w` field for dicts. Coordinated in PR #31.
+- **F48 reviewer prompt template version bumps**. F51's
+  homograph judge prompt template is at v1-homograph-ambiguous;
+  cache-key isolation per ADR-034 protects against version
+  collisions.
+- **Future OllamaHomographJudge implementation team**.
+  Currently the harness prompt has no production consumer.
+  When the team builds it, F51 must surface the threading
+  contract: prompt → JSON → dispatch on `pick_index` vs
+  `alternatives_indices`. Documented in ADR-040.
+
+## Open Questions
+
+- **Q-01 (BT-303)**: When OllamaHomographJudge ships, should
+  ambiguous-flagged tokens get a player UI affordance (e.g.,
+  "two readings; tap to switch")? Defer to F50 + F36 design.
+- **Q-02**: Should the rule lexicon be language-tagged (Hebrew-
+  only currently)? If F24 lang-switch ever activates for
+  loanwords, the rule may need to skip mixed-language tokens.
+  Defer until F24 work begins.
+- **Q-03 (BT-301 follow-up)**: At what trigger-lexicon size do
+  we move from Python-frozen to YAML-loaded? F21 (the related
+  static lookup) is YAML-loaded. F51 stays Python until either
+  size grows beyond ~30 entries OR a non-developer needs to
+  contribute.

--- a/.workitems/N02-hebrew-interpretation/F51-homograph-context-rules/functional-test-plan.md
+++ b/.workitems/N02-hebrew-interpretation/F51-homograph-context-rules/functional-test-plan.md
@@ -1,0 +1,120 @@
+<!-- Authored 2026-05-02 as Phase-0 design backfill; F51 was already merged in PR #29. -->
+
+# N02/F51 — Homograph Context-Rules: Functional Test Plan
+
+## Scope
+
+Verifies the rule-based context layer between Dicta-Nakdan output
+and the F48 correction cascade. Covers the possessive-mappiq rule
+(deterministic) and the Gemma homograph-judge prompt template
+(LLM, deferred consumer). Per ADR-038.
+
+## Source User Stories
+
+- **F51-S01** Reading-disabled student hears the right possessive
+  form — Critical
+- **F51-S02** Reviewer sees clearer reasoning in corrections.json — High
+- **F51-S03** Pipeline maintainer knows the cascade is regression-free — High
+- **F51-S04** `שלו` reads as "calm" when context demands (conditional T-05) — Medium
+
+## Test Scenarios
+
+- **FT-300** `apply_rule(sentence, focus, options)` returns the
+  1-based index of the first mappiq option when the sentence
+  contains a possessor trigger (e.g., `כל אם`). Critical
+  (F51-S01/AC-01).
+- **FT-301** `apply_rule` returns None when no possessor trigger
+  matches. Critical (F51-S01/AC-02).
+- **FT-302** `apply_rule` returns None when no mappiq variant
+  exists in the candidate list (even if trigger fires). High.
+- **FT-303** Trigger lexicon: `כל + {אם / אב / הורה / אישה /
+  איש / בן / בת / אדם}` — all 8 lemmas trigger the rule. High.
+- **FT-304** Negative case: `המשחק מתאים לכל ילד או ילדה` —
+  trigger word `ילד` is NOT in the lexicon; rule must NOT fire.
+  Critical.
+- **FT-305** Mappiq detection: word ending in `ה` followed by
+  U+05BC (DAGESH/MAPIQ) is recognised; word ending in `ה`
+  without U+05BC is not. Critical.
+- **FT-306** Pipe-prefix handling: `לְ|יַלְדָּהּ` → stem
+  `יַלְדָּהּ` correctly identified as mappiq-bearing.
+- **FT-307** Empty options list returns None. High.
+- **FT-308** Returns FIRST mappiq index when multiple exist
+  (for stable, deterministic output).
+- **FT-309** F19 Nakdan inference layer (`_apply_context_rules`)
+  calls `apply_rule` and overrides Nakdan's top-1 when the rule
+  fires. Critical.
+- **FT-310** When the rule does not fire, Nakdan's top-1 (or NLP-
+  contextualised pick) is preserved unchanged. Critical.
+- **FT-311** Provenance: when the rule fires, an entry of shape
+  `{stage: "context_rule", rule: "possessive-mappiq", picked_index:
+  <int>, fired: true}` is recorded in corrections.json. High.
+
+## Negative Tests
+
+- **FT-312** Rule does NOT fire on a sentence with `כל` but no
+  trigger noun (e.g., `כל יום`).
+- **FT-313** Rule does NOT fire on isolated `אם` without `כל`
+  prefix (e.g., `אם רוצה`).
+
+## Boundary Tests
+
+- **FT-314** Sentence with a single trigger word and a single
+  mappiq option: rule returns 1. Smallest non-trivial case.
+- **FT-315** Sentence with multiple trigger matches: rule still
+  returns the first mappiq index in the candidate list (matches
+  are not multiplied).
+
+## Permission and Role Tests
+
+- Read-only at runtime. The rule is a pure function over
+  `(sentence, focus, options)` — no I/O, no mutation.
+
+## Integration Tests
+
+- **FT-316** F19 → F51 → F48 chain: the override flows through
+  Nakdan inference, into the correction cascade, into
+  corrections.json with a proper stage entry.
+- **FT-317** Homograph judge prompt template
+  `tirvi/correction/prompts/he_homograph_judge/v1.txt` exists,
+  contains `{sentence}`, `{focus}`, `{options_block}` placeholders,
+  and references the four homograph categories (mappiq, prefix,
+  possessive-vs-adjective, interrogative-vs-noun).
+- **FT-318** Cache-key isolation per ADR-034: prompt template
+  version `v1-homograph-ambiguous` is distinct from the OCR
+  reviewer's `v1-scaffold`.
+
+## Audit and Traceability Tests
+
+- **FT-319** Every rule fire is auditable from corrections.json
+  back to ADR-038 and the F51 workitem.
+- **FT-320** F51 fixture at `tests/fixtures/homographs.yaml` covers
+  all 8 BlockType-equivalents for homograph cases (mother /
+  whether / calm / his / her-child / etc.) and aggregate strict
+  score ≥ 28/30.
+
+## Regression Risks
+
+- **R-01** Trigger lexicon expansion (e.g., adding `כל אדם`) over-
+  fires on metaphoric usage. Mitigation: regex anchored on word
+  boundaries; explicit negative tests in the F51 unit suite.
+- **R-02** F19 Nakdan inference reorganisation could break the
+  `_apply_context_rules` integration. Mitigation: integration
+  tests at `tests/unit/test_nakdan_inference_context_rules.py`
+  assert the contract.
+- **R-03** Gemma 4 31B does ~2-5k tokens of internal reasoning
+  before emitting JSON. Production callers MUST NOT cap
+  `num_predict` below ~6000. Mitigation: documented in
+  `_meta.yaml`; F48 reviewer regression test asserts.
+
+## Open Questions
+
+- **Q-01** Should the rule lexicon be YAML-loaded (like F21) or
+  Python-frozen (current)? Current is simpler; YAML lets non-
+  developers contribute. Defer until lexicon size grows.
+- **Q-02** Should T-05 (`she-conjoined-adjective` rule) ship as a
+  Python rule or stay deferred? Currently T-05 is conditional on
+  the harness prompt covering 100% of `שלו` cases; if it doesn't,
+  ship the rule. Awaiting OllamaHomographJudge measurement.
+- **Q-03** Should the F51 fixture exercise the full LLM judge
+  cascade? Currently rule-only; LLM judge is a heavyweight
+  integration. Defer to T-06 follow-up.

--- a/.workitems/N02-hebrew-interpretation/F51-homograph-context-rules/ontology-delta.yaml
+++ b/.workitems/N02-hebrew-interpretation/F51-homograph-context-rules/ontology-delta.yaml
@@ -1,0 +1,146 @@
+# Ontology delta — N02/F51 Homograph Context-Rules
+# Authored 2026-05-02 as Phase-0 design backfill; F51 already merged in PR #29.
+
+version: 1
+feature_id: N02/F51
+
+modules:
+  - id: MOD-N02-F51-possessive-mappiq
+    name: tirvi.homograph.possessive_mappiq
+    description: |
+      Pure deterministic rule. Detects possessor patterns in Hebrew
+      sentences (כל + {אם/אב/הורה/אישה/איש/בן/בת/אדם}) and prefers
+      mappiq-bearing candidates of the focus word when the trigger
+      fires.
+    feature_refs: [N02/F51]
+    bounded_context: hebrew_nlp
+    source_path: tirvi/homograph/possessive_mappiq.py
+    status: implemented
+  - id: MOD-N02-F51-nakdan-context-rules
+    name: tirvi.adapters.nakdan.inference._apply_context_rules
+    description: |
+      F19 inference helper that runs F51 rules before falling through
+      to NLP-context picks. Calls possessive-mappiq; future rules
+      (e.g., she-conjoined-adjective) plug into the same dispatch.
+    feature_refs: [N02/F19, N02/F51]
+    bounded_context: hebrew_nlp
+    source_path: tirvi/adapters/nakdan/inference.py
+    status: implemented
+  - id: MOD-N02-F51-prompt-template
+    name: tirvi.correction.prompts.he_homograph_judge
+    description: |
+      Linguistic-harness prompt template for the future
+      OllamaHomographJudge ICascadeStage (deferred per ADR-038).
+      Template version v1-homograph-ambiguous (per ADR-040
+      uncertainty addition).
+    feature_refs: [N02/F48, N02/F51]
+    bounded_context: hebrew_nlp
+    source_path: tirvi/correction/prompts/he_homograph_judge/v1.txt
+    status: implemented
+
+services: []
+ports: []
+adapters: []
+
+classes: []  # No new dataclasses; rule is a pure function.
+
+functions:
+  - id: FN-N02-F51-apply-rule
+    name: apply_rule
+    description: |
+      apply_rule(sentence, focus, options) -> int | None. Returns
+      1-based index of preferred mappiq option when trigger fires
+      AND a mappiq variant exists in candidates. Returns None for
+      fall-through.
+    feature_refs: [N02/F51]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F51-possessive-mappiq
+    source_path: tirvi/homograph/possessive_mappiq.py
+    status: implemented
+  - id: FN-N02-F51-has-possessor-trigger
+    name: _has_possessor_trigger
+    description: |
+      Returns True iff the sentence matches any pattern in
+      _POSSESSOR_TRIGGERS (currently a single regex covering
+      `כל + 8 trigger nouns`).
+    feature_refs: [N02/F51]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F51-possessive-mappiq
+    source_path: tirvi/homograph/possessive_mappiq.py
+    status: implemented
+  - id: FN-N02-F51-has-mappiq-on-final-he
+    name: _has_mappiq_on_final_he
+    description: |
+      Returns True iff the candidate's stem ends with `ה` + U+05BC
+      (mappiq). Handles pipe-prefix marker by splitting on `|`
+      and inspecting the stem.
+    feature_refs: [N02/F51]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F51-possessive-mappiq
+    source_path: tirvi/homograph/possessive_mappiq.py
+    status: implemented
+
+constants:
+  - id: CONST-N02-F51-possessor-triggers
+    name: _POSSESSOR_TRIGGERS
+    description: |
+      tuple of compiled regex patterns. Initial: `\bכל\s+(אם|אב|הורה|
+      אישה|איש|בן|בת|אדם)\b`. Conservative; extension requires unit
+      test + reviewer sign-off per BT-301.
+    feature_refs: [N02/F51]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F51-possessive-mappiq
+    source_path: tirvi/homograph/possessive_mappiq.py
+    status: implemented
+  - id: CONST-N02-F51-mappiq-codepoint
+    name: _MAPPIQ
+    description: U+05BC HEBREW POINT DAGESH OR MAPIQ OR SHURUQ.
+    feature_refs: [N02/F51]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F51-possessive-mappiq
+    source_path: tirvi/homograph/possessive_mappiq.py
+    status: implemented
+
+adr_decisions:
+  - id: adr:038
+    name: homograph context-rules layer
+    description: F51 design decision — rule layer between Nakdan and F48 reviewer; conservative trigger lexicon; lex-based heuristic scoring (extended in ADR-039).
+    feature_refs: [N02/F51]
+    status: proposed
+  - id: adr:040
+    name: ambiguous verdict shape
+    description: F51 prompt template version bumped to v1-homograph-ambiguous to support pick_index: null + alternatives_indices on genuinely two-valued sentences.
+    feature_refs: [N02/F51]
+    status: proposed
+
+tasks:
+  - id: task:N02/F51/T-01
+    name: possessive-mappiq-rule-promote
+    feature_refs: [N02/F51]
+    spec_refs: [spec:N02/F51/DE-01]
+    test_path: tests/unit/test_possessive_mappiq.py
+    status: implemented
+  - id: task:N02/F51/T-02
+    name: nakdan-inference-wiring
+    feature_refs: [N02/F19, N02/F51]
+    spec_refs: [spec:N02/F51/DE-02]
+    test_path: tests/unit/test_nakdan_inference_context_rules.py
+    status: implemented
+  - id: task:N02/F51/T-03
+    name: homograph-judge-prompt-template
+    feature_refs: [N02/F48, N02/F51]
+    spec_refs: [spec:N02/F51/DE-03]
+    test_path: tests/unit/test_he_homograph_judge_template.py
+    status: implemented
+  - id: task:N02/F51/T-04
+    name: regression-fixture-corpus
+    feature_refs: [N02/F51]
+    spec_refs: [spec:N02/F51/DE-04]
+    test_path: tests/integration/test_homograph_cascade.py
+    status: implemented
+  - id: task:N02/F51/T-05
+    name: she-conjoined-adjective-rule
+    feature_refs: [N02/F51]
+    spec_refs: [spec:N02/F51/DE-05]
+    test_path: tests/unit/test_she_conjoined_adjective.py
+    status: deferred  # conditional on harness prompt 100% coverage; not built

--- a/.workitems/N02-hebrew-interpretation/F52-block-kind-taxonomy/behavioural-test-plan.md
+++ b/.workitems/N02-hebrew-interpretation/F52-block-kind-taxonomy/behavioural-test-plan.md
@@ -1,0 +1,127 @@
+<!-- Authored 2026-05-02 as Phase-0 design backfill; F52 was already merged in PR #34. -->
+
+# N02/F52 — Block-kind Taxonomy Completion: Behavioural Test Plan
+
+## Patterns Covered
+
+| Behaviour                                                  | Persona                | Risk                                         | Test     |
+|------------------------------------------------------------|------------------------|----------------------------------------------|----------|
+| Student wants "Question 3 of 12" hint while listening       | P01 (ל"ל student)     | unknown current question                     | BT-200   |
+| Maintainer extends cue lexicon for new exam format         | P11 (NLP maintainer)   | over-classification breaks existing pages    | BT-201   |
+| Reviewer audits a misclassified block in F50 portal        | P08 (QA / teacher)     | invisible classification decision             | BT-202   |
+| Pipeline encounters an unfamiliar Bagrut format            | P11                    | every block falls to `mixed` fallback        | BT-203   |
+| Page has nested instruction inside a question_stem         | P01                    | wrong block boundary breaks audio flow       | BT-204   |
+| Multi-choice options at the end of a section               | P01                    | choices mistaken for paragraph               | BT-205   |
+| F22 schema rev breaks F33 viewer                           | P08                    | rendering crash on the new field             | BT-206   |
+
+## Scenarios
+
+- **BT-200** Student loads Economy.pdf in the player. Page has 3
+  question_stem blocks. F39 (downstream) renders "שאלה 1 מתוך 3"
+  hint. Student presses J twice; F39 advances marker through the
+  question_stem blocks F52 identified. Behaviourally: F52's
+  `question_stem` classification is the load-bearing signal for
+  F39's affordance. (Cross-feature integration test owned by F39
+  T-07; F52 contributes the precondition.)
+
+- **BT-201** Maintainer notices that some Mechina exams use
+  `קרא את הטקסט הבא` instead of `קרא בעיון`. PR adds the new
+  prefix to `_INSTRUCTION_PREFIXES`. Reviewer asks for FT case;
+  PR adds it as I06 in the regression fixture. Strict score
+  stays ≥ 28/30. Lexicon evolves with corpus, not against it.
+
+- **BT-202** Teacher reviewing a Bagrut page in F50 portal sees a
+  block flagged as `multi_choice_options` but the printed text
+  is actually four bullet points (not multiple-choice answers).
+  Tooltip shows ADR-041 #20 + the cue hit ("3+ א./ב./ג./ד.
+  prefixes"). Teacher overrides via corrections.json edit; F52
+  classifier doesn't change. The override is logged for future
+  cue-tuning analysis. (Behaviour: portal interaction; F50 owns
+  UI.)
+
+- **BT-203** Pipeline ingests a non-Bagrut Hebrew exam (Mechina
+  format with different cue patterns). 70% of blocks fall to
+  `mixed` fallback. Audio still plays (mixed renders as
+  paragraph at TTS layer). Reviewer sees the high `mixed` rate
+  in F50 portal as a signal that this exam type needs lexicon
+  extension. Behaviourally graceful degradation — never crashes,
+  audio always plays.
+
+- **BT-204** A Bagrut civics question has the structure
+  "Read the passage. Q3: Based on..." where the "Read..."
+  sentence is INSIDE the question_stem block. F11 segmenter does
+  not split mid-block, so the F52 classifier sees a single block
+  starting with "Read"; cue matching picks `instruction` based
+  on the leading prefix. The `question_stem` part is mis-
+  classified. Mitigation: not solvable at F52 alone — needs F11
+  to split. Documented invariant: F52 classifies whatever F11
+  hands it, no re-segmentation.
+
+- **BT-205** A multi-choice section's `א./ב./ג./ד.` block sits
+  immediately after the question_stem. F11 segmentation puts
+  them in separate blocks (line-gap heuristic). F52 classifies
+  the choice block as `multi_choice_options`. Audio: F23
+  emits the four choices in order; F39 (downstream) does NOT
+  auto-pause between choices (only at question_stem block end
+  per its design). Student hears choices contiguously, then
+  pauses at the next question_stem.
+
+- **BT-206** F22 schema rev introduces a new `transformations[]`
+  shape. F33 viewer expects the field to be a list of dicts;
+  reads `block.get('transformations', [])`. F52 emits empty
+  tuple by default; viewer renders blocks with no provenance
+  the same as legacy plan.json files. No crash.
+
+## Edge / Misuse / Recovery
+
+- **Edge: a block's first 3 words form a multi-language phrase**
+  ("הוראות: SECTION A"). The cue match scans the first 3 tokens
+  and finds `הוראות`; classification is `instruction`. The
+  English token `SECTION` is irrelevant to the classifier (only
+  prefix matters).
+- **Edge: misspelled cue** (`הוארות` for `הוראות`). Cue match
+  fails; falls through to `paragraph` (or `mixed` if short).
+  Reviewer in F50 portal can override via corrections.json edit.
+- **Misuse: developer adds a regex wildcard to `_INSTRUCTION_PREFIXES`**
+  (e.g., `הוראה.*`). Architecture forbids this — prefixes are
+  exact-string. PR review enforces; if it slips through, the
+  fixture corpus catches over-classification.
+- **Recovery: classifier raises**. Should not happen — pure
+  function. If it does, F11 aggregator's `_make_block` would
+  surface the exception; the page fails to segment and ingest
+  alerts. Tracked as R-05 in the FT plan; current contract is
+  total (no exceptions).
+
+## Collaboration Breakdown
+
+- **F11 maintainer changes block-segmentation heuristic**. F52
+  classifier consumes `OCRWord` lists from F11; if F11 starts
+  splitting mid-paragraph (e.g., on column boundaries), the
+  classifier sees fragments and may mis-classify. Mitigation:
+  F11 contract test asserts block boundary stability across
+  refactors.
+- **F22 plan aggregator changes `Block`→`PlanBlock` mapping**.
+  F52 added `transformations` propagation; if F22 is later
+  refactored to drop the field, F52's audit trail is lost.
+  Mitigation: F22's regression suite asserts the field
+  round-trip.
+- **F50 portal team adds new `transformations[]` consumer**.
+  Currently consumers expect `kind: "block_kind_classification"`
+  ; if a future entry uses a different kind (e.g.,
+  `clause_split` from F53, `acronym_expansion` from F15), the
+  portal renderer must dispatch on `kind`. Coordinated via the
+  `transformations[]` schema doc (deferred — see F22 follow-up).
+
+## Open Questions
+
+- **Q-01 (BT-203)**: At what `mixed`-rate threshold does the
+  F50 portal raise an alert ("this exam format needs cue
+  lexicon extension")? Defer to F50 design.
+- **Q-02 (BT-204)**: Should F52 emit a "subordinate
+  classification" (e.g., `instruction|question_stem` for blocks
+  where two cues partially match)? Currently first-match-wins;
+  ambiguous blocks lose information. Defer until corpus shows
+  the gap.
+- **Q-03**: Should `paragraph` blocks longer than N words emit
+  a "complex paragraph" flag for F53 chunker priority? Cross-
+  feature concern; defer until both features have measurement.

--- a/.workitems/N02-hebrew-interpretation/F52-block-kind-taxonomy/functional-test-plan.md
+++ b/.workitems/N02-hebrew-interpretation/F52-block-kind-taxonomy/functional-test-plan.md
@@ -1,0 +1,139 @@
+<!-- Authored 2026-05-02 as Phase-0 design backfill; F52 was already merged in PR #34. -->
+
+# N02/F52 — Block-kind Taxonomy Completion: Functional Test Plan
+
+## Scope
+
+Verifies that the F11 block segmenter recognises the five new block
+kinds — `instruction`, `question_stem` (legacy), `datum`,
+`answer_blank`, `multi_choice_options` — alongside the legacy
+`paragraph` / `heading` / `mixed`. Verifies the `mixed` fallback
+(per Q2 answer in PR #30) for short ambiguous blocks. Verifies that
+`PlanBlock.transformations[]` carries audit-trail provenance for
+confident non-fallback classifications referencing ADR-041 row #20.
+
+## Source User Stories
+
+- **F52-S01** Reading-disabled student knows when a question starts
+  and ends — Critical
+- **F52-S02** Pipeline maintainer can extend cue lexicon without
+  breaking pages — High
+- **F52-S03** F22 plan.json schema accepts expanded enum without
+  breaking producers — Critical
+- **F52-S04** Reviewer can audit every taxonomy decision — High
+- **F52-S05** Fixture corpus catches regressions before
+  production — High
+- **F52-S06** Phase 0 demo on Economy.pdf (deferred T-06) — Medium
+
+## Test Scenarios
+
+- **FT-200** Block starting with `הוראות` → `instruction` with
+  confidence ≥ 0.6. Critical (F52-S01/AC-02).
+- **FT-201** Block starting with `קרא בעיון` → `instruction`. High.
+- **FT-202** Block starting with `שים לב` → `instruction`. Medium.
+- **FT-203** Block starting with `נתונים` → `datum` with confidence
+  ≥ 0.6. High.
+- **FT-204** Block with ≥ 3 distinct `א./ב./ג./ד.` letter prefixes
+  → `multi_choice_options` with confidence ≥ 0.6. Critical.
+- **FT-205** Block with `שאלה N <text>` prefix → `question_stem`
+  (legacy F11 path preserved). Critical (F52-S01/AC-01).
+- **FT-206** Empty word list → `answer_blank`. Medium.
+- **FT-207** Block with `≥ 1.5×` modal-height words → `heading`
+  (legacy F11 path preserved). High.
+- **FT-208** Block with ≤ 2 words and no cue match → `mixed`
+  fallback (NOT `paragraph` — per Q2). Critical (F52-S02/AC-01).
+- **FT-209** Block with > 2 words and no cue match → `paragraph`
+  (legacy fallback). High.
+- **FT-210** Confident non-fallback classification (≥ 0.6 + kind
+  ∈ {instruction, datum, answer_blank, multi_choice_options,
+  question_stem, heading}) emits exactly one
+  `transformations[]` entry of shape
+  `{kind: "block_kind_classification", to: <BlockType>,
+  confidence: <float>, adr_row: "ADR-041 #20"}`. Critical
+  (F52-S04/AC-01).
+- **FT-211** `paragraph` and `mixed` fallback kinds emit NO
+  provenance entry. Critical.
+- **FT-212** `Block.transformations` is a `tuple[dict, ...]`,
+  default empty `()`. High.
+- **FT-213** F22's plan aggregator copies `Block.transformations`
+  to `PlanBlock.transformations` unchanged. Critical
+  (F52-S03/AC-01).
+
+## Negative Tests
+
+- **FT-214** Block starting with `הוראות` followed by NOTHING →
+  still `instruction` (single-word edge — but cue match wins;
+  documented as accepted noise).
+- **FT-215** Block with TWO `א./ב.` prefixes only (not 3) → does
+  NOT trigger `multi_choice_options`; falls through to
+  `paragraph` or `mixed`. High — boundary check on the ≥ 3
+  threshold.
+- **FT-216** Block with `נתונים` mid-sentence (not as prefix) →
+  does NOT trigger `datum`. High — prefix-only match.
+
+## Boundary Tests
+
+- **FT-217** Block at exactly 2 words → `mixed` fallback (the
+  threshold is inclusive of 2-word blocks).
+- **FT-218** Block at exactly 3 words → `paragraph` fallback (one
+  word over the `mixed` threshold).
+- **FT-219** Block with confidence exactly 0.6 → emits
+  provenance (threshold is `>=`, not `>`).
+
+## Permission and Role Tests
+
+- Read-only at runtime. Classifier is a pure function over
+  `OCRWord` lists + `PageStats`; no I/O, no mutation.
+
+## Integration Tests
+
+- **FT-244** F11 → F52 → F22 chain: a block classified
+  `instruction` flows through `_make_block` → `Block(block_type=
+  instruction, transformations=({...},))` → F22 aggregator →
+  `PlanBlock(block_type=instruction, transformations=({...},))`.
+- **FT-245** Mixed-language block (Hebrew + English) classifies
+  on the leading Hebrew tokens; English fragments don't break
+  the classifier.
+
+## Audit and Traceability Tests
+
+- **FT-246** Every `transformations[]` entry from this feature
+  carries `adr_row: "ADR-041 #20"`. Auditable from `corrections.json`
+  / F50 portal back to the binding ADR row.
+- **FT-247** Fixture corpus (T-05) achieves strict score ≥ 28/30
+  (≥ 93%) on synthetic cases.
+
+## Regression Risks
+
+- **R-01** Cue lexicon edits could over-classify: adding
+  `נתון` (singular) to `_DATUM_PREFIXES` would trigger on common
+  paragraph openings. Mitigation: prefix-only match + explicit
+  cue lexicon constants (no regex wildcards) + reviewer must add
+  a test per cue addition.
+- **R-02** F22 schema bump on `transformations[]` could break F33
+  / F50 portal renderers expecting the legacy shape. Mitigation:
+  field is OPTIONAL with default `()` — old plan.json files
+  continue to validate.
+- **R-03** The `mixed` fallback contract change (was `paragraph`
+  for short blocks) could regress downstream F23 / F35 components
+  that special-case `paragraph`. Mitigation: full regression suite
+  green (980 passed before merge); legacy test renamed/updated.
+- **R-04** Real Bagrut text uses cue patterns the lexicon doesn't
+  cover (e.g., `מטרת הפעילות` for instruction, `הניתונים שלפניכם`
+  for datum). Mitigation: T-06 measurement on Economy.pdf and the
+  3 backfilled exam PDFs will surface gaps; lexicon extends with
+  unit tests per addition.
+
+## Open Questions
+
+- **Q-01** Should `paragraph` ALSO emit provenance (e.g., to record
+  "no confident kind matched")? Currently the absence of an entry
+  IS the signal. Defer until F50 portal asks for explicit
+  fallback markers.
+- **Q-02** Does the `multi_choice_options` cue need to handle
+  numeric variants (`1./2./3./4.`) common in some Bagrut sections?
+  Defer until the corpus measurement shows the gap.
+- **Q-03** Sub-questions (a/b/c within a stem) — are they
+  separate `question_stem` blocks or tokens within one? Currently
+  one block per top-level question. F39 designs depend on this
+  contract; revisit if F39 implementation finds it limiting.

--- a/.workitems/N02-hebrew-interpretation/F52-block-kind-taxonomy/ontology-delta.yaml
+++ b/.workitems/N02-hebrew-interpretation/F52-block-kind-taxonomy/ontology-delta.yaml
@@ -1,0 +1,171 @@
+# Ontology delta — N02/F52 Block-kind Taxonomy Completion
+# Authored 2026-05-02 as Phase-0 design backfill; F52 already merged in PR #34.
+
+version: 1
+feature_id: N02/F52
+
+modules:
+  - id: MOD-N02-F52-taxonomy
+    name: tirvi.blocks.taxonomy
+    description: |
+      BlockType Literal expanded from 3 (heading / paragraph /
+      question_stem) to 8 — adds mixed (Q2 fallback), instruction,
+      datum, answer_blank, multi_choice_options. Legacy three keep
+      front-of-tuple position for any rank-aware consumer.
+    feature_refs: [N01/F11, N02/F52]
+    bounded_context: hebrew_nlp
+    source_path: tirvi/blocks/taxonomy.py
+    status: implemented
+  - id: MOD-N02-F52-classifier-ext
+    name: tirvi.blocks.classifier
+    description: |
+      F11 heuristic classifier — extended in F52 with priority-ordered
+      cue dispatch table. New predicates: _is_instruction (3 prefixes),
+      _is_datum (1 prefix), _is_multi_choice (≥ 3 letter-prefixes).
+      Below-confidence fallback split: short ambiguous → mixed; long
+      plain → paragraph.
+    feature_refs: [N01/F11, N02/F52]
+    bounded_context: hebrew_nlp
+    source_path: tirvi/blocks/classifier.py
+    status: implemented
+  - id: MOD-N02-F52-aggregation-ext
+    name: tirvi.blocks.aggregation
+    description: |
+      F11 block aggregator — extended in F52 with
+      _build_classification_provenance helper. Emits one
+      transformations[] entry on confident non-fallback classifications.
+    feature_refs: [N01/F11, N02/F52]
+    bounded_context: hebrew_nlp
+    source_path: tirvi/blocks/aggregation.py
+    status: implemented
+  - id: MOD-N02-F52-plan-ext
+    name: tirvi.plan.value_objects + tirvi.plan.aggregates
+    description: |
+      F22 plan-block VO — extended in F52 with optional
+      transformations field; aggregator copies the upstream
+      Block.transformations field through unchanged.
+    feature_refs: [N02/F22, N02/F52]
+    bounded_context: hebrew_nlp
+    source_path: tirvi/plan/value_objects.py + tirvi/plan/aggregates.py
+    status: implemented
+
+services: []
+ports: []
+adapters: []
+
+classes:
+  - id: CLS-N02-F52-Block-transformations-field
+    name: Block.transformations  # field, not class
+    description: |
+      Optional tuple[dict, ...] field on tirvi.blocks.Block. Default
+      empty (). Populated by F52 classifier with one entry per
+      confident non-fallback pick. Audit-trail for F50 portal review.
+    feature_refs: [N02/F52]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F52-aggregation-ext
+    source_path: tirvi/blocks/value_objects.py
+    status: implemented
+
+functions:
+  - id: FN-N02-F52-classify-block
+    name: classify_block
+    description: |
+      Returns (BlockType, confidence). Walks priority-ordered cue
+      dispatch table; first match wins. Fallback to mixed (≤ 2 words)
+      or paragraph (long).
+    feature_refs: [N02/F52]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F52-classifier-ext
+    source_path: tirvi/blocks/classifier.py
+    status: implemented
+  - id: FN-N02-F52-build-classification-provenance
+    name: _build_classification_provenance
+    description: |
+      Emits one transformations[] entry of shape
+      {kind: "block_kind_classification", to: <BlockType>,
+       confidence: <float>, adr_row: "ADR-041 #20"} when confidence
+      ≥ 0.6 AND kind is non-fallback. Empty tuple otherwise.
+    feature_refs: [N02/F52]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F52-aggregation-ext
+    source_path: tirvi/blocks/aggregation.py
+    status: implemented
+
+constants:
+  - id: CONST-N02-F52-block-types
+    name: BLOCK_TYPES
+    description: tuple[BlockType, ...] of all 8 valid block kinds.
+    feature_refs: [N02/F52]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F52-taxonomy
+    source_path: tirvi/blocks/taxonomy.py
+    status: implemented
+  - id: CONST-N02-F52-instruction-prefixes
+    name: _INSTRUCTION_PREFIXES
+    description: 3-tuple — הוראות / קרא בעיון / שים לב.
+    feature_refs: [N02/F52]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F52-classifier-ext
+    source_path: tirvi/blocks/classifier.py
+    status: implemented
+  - id: CONST-N02-F52-datum-prefixes
+    name: _DATUM_PREFIXES
+    description: 1-tuple — נתונים. Extensible.
+    feature_refs: [N02/F52]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F52-classifier-ext
+    source_path: tirvi/blocks/classifier.py
+    status: implemented
+  - id: CONST-N02-F52-letter-choice-re
+    name: _LETTER_CHOICE_RE
+    description: regex `^[א-ד]\.$` — matches single letter-prefix tokens.
+    feature_refs: [N02/F52]
+    bounded_context: hebrew_nlp
+    module_ref: MOD-N02-F52-classifier-ext
+    source_path: tirvi/blocks/classifier.py
+    status: implemented
+
+adr_decisions:
+  - id: adr:041
+    name: red-line decision register
+    description: F52 entry — row #20 (verbal block markers ALLOW with caution; rendering of structural information present in printed exam).
+    feature_refs: [N02/F52]
+    status: proposed
+
+tasks:
+  - id: task:N02/F52/T-01
+    name: blocktype-enum-extension
+    feature_refs: [N02/F52]
+    spec_refs: [spec:N02/F52/DE-01]
+    test_path: tests/unit/test_block_taxonomy_f52.py
+    status: implemented
+  - id: task:N02/F52/T-02
+    name: classifier-cue-extension
+    feature_refs: [N02/F52]
+    spec_refs: [spec:N02/F52/DE-02]
+    test_path: tests/unit/test_block_classifier_f52.py
+    status: implemented
+  - id: task:N02/F52/T-03
+    name: planblock-contract-propagation
+    feature_refs: [N02/F22, N02/F52]
+    spec_refs: [spec:N02/F52/DE-03]
+    test_path: tests/unit/test_block_provenance_f52.py
+    status: implemented
+  - id: task:N02/F52/T-04
+    name: classifier-provenance-emission
+    feature_refs: [N02/F52]
+    spec_refs: [spec:N02/F52/DE-04]
+    test_path: tests/unit/test_block_provenance_f52.py
+    status: implemented
+  - id: task:N02/F52/T-05
+    name: regression-fixture-corpus
+    feature_refs: [N02/F52]
+    spec_refs: [spec:N02/F52/DE-05]
+    test_path: tests/integration/test_block_taxonomy_corpus.py
+    status: implemented
+  - id: task:N02/F52/T-06
+    name: economy-pdf-demo-smoke
+    feature_refs: [N02/F52]
+    spec_refs: [spec:N02/F52/DE-05]
+    test_path: tests/integration/test_economy_pdf_taxonomy_smoke.py
+    status: deferred  # heavyweight integration — DictaBERT + real OCR

--- a/.workitems/N04-player/F39-pause-after-question/behavioural-test-plan.md
+++ b/.workitems/N04-player/F39-pause-after-question/behavioural-test-plan.md
@@ -1,0 +1,120 @@
+<!-- Authored 2026-05-02 as Phase-0 design backfill (pre-implementation). -->
+
+# N04/F39 — Pause-and-Jump Affordance: Behavioural Test Plan
+
+## Patterns Covered
+
+| Behaviour                                                   | Persona               | Risk                                          | Test     |
+|-------------------------------------------------------------|-----------------------|-----------------------------------------------|----------|
+| Student takes time to think after each question              | P01 (ל"ל student)    | rushed by next question audio                 | BT-260   |
+| Teacher demos product to a class                             | P08 (teacher)         | confusing controls undermine demo             | BT-261   |
+| Student wants to skip ahead to a specific question           | P01                   | scrubbing audio is hard                       | BT-262   |
+| Student returns to a previous question to re-listen          | P01                   | loses place; takes long to relocate           | BT-263   |
+| Teacher disables auto-pause for advanced students            | P08                   | toggle UX too hidden                          | BT-264   |
+| Student loses focus mid-page                                 | P01                   | pause point lost on page reload               | BT-265   |
+| Student uses screen reader on the player UI                  | P01 (ל"ל + visual)    | toggle / hint not announced                   | BT-266   |
+
+## Scenarios
+
+- **BT-260** Student listens to question 1 of an Economy.pdf
+  page. Audio finishes; player auto-pauses. Student stays on
+  the page, thinks for ~30 seconds, then presses Space to
+  resume. Audio plays question 2 (the next non-question_stem
+  content + the next question_stem). Auto-pause fires again at
+  end of question 2. Student feels in control of pacing.
+
+- **BT-261** Teacher demos to a 10-student class. Plays
+  Economy.pdf page 1; auto-pause fires; teacher presses J to
+  show "see, you can skip to the next question without scrubbing".
+  Class understands. Teacher then opens settings panel, toggles
+  auto-pause OFF, plays again — audio runs continuously to
+  show the contrast. Behaviourally: settings panel + tooltip +
+  J/K must be discoverable on first encounter.
+
+- **BT-262** Student wants to start from question 5 (because
+  they already answered 1-4 in pencil). Student presses J four
+  times from page load; marker advances 1 → 2 → 3 → 4 → 5.
+  Audio is paused (player was in initial-paused state).
+  Student presses Space; audio plays question 5 onwards. No
+  manual scrub.
+
+- **BT-263** Student is on question 7; realises they want to
+  re-listen to question 5. Presses K twice. Marker reverses
+  7 → 6 → 5. Audio plays question 5 (or stays paused per
+  current state). Student listens; presses K once more; marker
+  goes to question 4. Pattern is reversible.
+
+- **BT-264** Teacher tells advanced student "you don't need
+  auto-pause, your reading is fast enough". Student opens
+  settings panel, finds the toggle, reads the tooltip,
+  disables it. Plays audio; runs continuously. Student
+  demonstrates self-advocacy. Behavioural: tooltip must
+  explain WHY a student might want to disable (ergonomic vs.
+  accommodation).
+
+- **BT-265** Student listens to half a Bagrut page; closes
+  laptop. Returns 2 hours later, opens browser to the same
+  URL. Page reloads. AutoPausePolicy state is restored from
+  localStorage (still ON). QuestionIndex resets to 1 of N
+  (no resume — page reload is page reload). Student hits
+  Space to start; lands on question 1, not where they left
+  off. Documented limitation: F39 does not persist mid-page
+  position.
+
+- **BT-266** Visually-impaired student uses screen reader.
+  ProgressHint widget has `aria-live="polite"` so the screen
+  reader announces "שאלה 3 מתוך 12" when current question
+  changes. Settings panel toggle has `aria-label` and the
+  tooltip is keyboard-accessible. F38 WCAG conformance gates
+  this; F39 implementation must include the markup.
+
+## Edge / Misuse / Recovery
+
+- **Edge: page with ZERO question_stem blocks**. ProgressHint
+  hidden (or "0 of 0"); J/K no-op. AutoPausePolicy has nothing
+  to act on. Player behaves like pre-F39 — auto-pause is
+  silently inactive.
+- **Edge: very long question_stem (single block, 200+ words)**.
+  F53 chunker may split mid-block; F39 still only pauses at
+  block_end (not at chunker breaks). Student gets ONE pause
+  per question, regardless of internal chunks. Documented
+  invariant.
+- **Misuse: developer adds another shortcut binding to J or K
+  in F36**. Conflict; F39's binding is reserved. Mitigation:
+  F36's keyboard router test asserts no overlap with F39's
+  reserved set.
+- **Recovery: localStorage corrupted / wrong type**. Riverpod
+  state initialiser catches `JSON.parse` errors; resets to
+  default `enabled=true`; logs to console. State recovers on
+  next toggle write.
+
+## Collaboration Breakdown
+
+- **F35 maintainer changes word-sync event names**. F39 binds
+  on `block_boundary` events to update QuestionIndex. If F35
+  renames or removes the event, F39 silently breaks. Mitigation:
+  contract test asserts the event name; F35 includes F39 in
+  its impact analysis.
+- **F36 maintainer reorganises settings panel layout**. F39's
+  toggle row position depends on F36's panel structure.
+  Mitigation: panel ordering is data-driven (a list); F39
+  appends its row; F36 doesn't break F39 by reorganising
+  unless it changes the data structure.
+- **F38 audit team flags a WCAG issue with the J/K shortcut
+  visibility**. F39 already includes tooltip + aria. If F38
+  demands additional markers (e.g., visible keyboard hint
+  bar), F39 follows up.
+
+## Open Questions
+
+- **Q-01 (BT-265)**: Should F39 persist mid-page position?
+  Open product question. Pros: better UX for interrupted
+  sessions. Cons: privacy (where I left off is now persisted),
+  technical (F35 marker state needs serialisation). Defer to
+  user feedback.
+- **Q-02 (BT-266)**: Does Hebrew screen reader (e.g., NVDA
+  with Hebrew voice pack) correctly announce
+  `aria-live="polite"` on Hebrew text? Defer to F38 audit.
+- **Q-03**: Should `J` ALSO work outside the player widget
+  (e.g., when focus is on a print view)? Defer to F36
+  keyboard-routing follow-up.

--- a/.workitems/N04-player/F39-pause-after-question/functional-test-plan.md
+++ b/.workitems/N04-player/F39-pause-after-question/functional-test-plan.md
@@ -1,0 +1,150 @@
+<!-- Authored 2026-05-02 as Phase-0 design backfill (pre-implementation). -->
+
+# N04/F39 — Pause-and-Jump Affordance: Functional Test Plan
+
+## Scope
+
+Verifies player auto-pauses at the end of every `question_stem`
+block when AutoPausePolicy is enabled (default ON). Verifies `J` /
+`K` keyboard navigation between question_stem blocks. Verifies the
+"שאלה N מתוך M" progress hint widget. Verifies persistence of the
+auto-pause toggle in localStorage. Per ADR-041 row #5 (auto-pause
+allowed under Israeli MoE Level 1 accommodation framework).
+
+## Source User Stories
+
+- **F39-S01** Student relies on auto-pause being on by default —
+  Critical
+- **F39-S02** Student sees current question position — High
+- **F39-S03** Auto-pause fires at question end when toggle on —
+  Critical
+- **F39-S04** Keyboard J/K navigates between questions — High
+- **F39-S05** ProgressHint widget renders position — Medium
+- **F39-S06** Settings panel exposes toggle — Medium
+- **F39-S07** Phase 0 demo on Economy.pdf — Critical
+
+## Test Scenarios
+
+- **FT-260** AutoPausePolicy default state on first load (no
+  localStorage key) is `enabled=true`. Critical (F39-S01/AC-01).
+- **FT-261** AutoPausePolicy state persists in localStorage under
+  key `tirvi.player.auto_pause_after_question`. High.
+- **FT-262** Toggle change in settings panel updates the
+  Riverpod-bound state AND writes to localStorage atomically.
+  High.
+- **FT-263** QuestionIndex.from_plan returns
+  `{current: 1, total: 3}` on a plan with 3 question_stem blocks
+  before any marker advances. High (F39-S02/AC-01).
+- **FT-264** Marker crossing into question N+1 updates
+  QuestionIndex.current to N+1. Critical.
+- **FT-265** State machine transitions to `paused` on
+  block_end event when block_kind == question_stem AND
+  AutoPausePolicy.enabled. Critical (F39-S03/AC-01).
+- **FT-266** State machine does NOT pause on block_end for
+  non-question_stem blocks (paragraph, datum, etc.) regardless of
+  policy state. Critical.
+- **FT-267** Toggle off mid-page during a pause: current pause
+  REMAINS until user manually resumes; future question_stem
+  block_end events do NOT pause. High (F39-S03/AC-01 second
+  clause).
+- **FT-268** Keyboard `J`: marker advances to start of next
+  question_stem block. Audio resumes from that point IF player
+  was playing; remains paused IF player was paused. Critical
+  (F39-S04/AC-01).
+- **FT-269** Keyboard `K`: marker reverses to start of previous
+  question_stem block. Same audio-state semantics as J.
+  Critical.
+- **FT-270** Keyboard `J` on the LAST question_stem: no-op (or
+  optional audio cue — defer). Medium.
+- **FT-271** Keyboard `K` on the FIRST question_stem: no-op.
+  Medium.
+- **FT-272** ProgressHint widget displays "שאלה N מתוך M" with
+  correct N (current) and M (total). Renders adjacent to
+  play/pause control. High (F39-S05/AC-01).
+- **FT-273** Settings panel renders an auto-pause toggle row
+  with localised label ("השהיה אוטומטית בסוף שאלה") and tooltip
+  describing J/K shortcuts. Medium (F39-S06/AC-01).
+
+## Negative Tests
+
+- **FT-274** Plan with ZERO question_stem blocks: ProgressHint
+  is hidden (or shows "0 of 0" — defer to T-05 measurement).
+  J/K keys are no-op. AutoPausePolicy state has no effect (no
+  question_stem block_end events possible).
+- **FT-275** Plan with question_stem mid-page that is later
+  reclassified by F50 portal edit: Player does NOT auto-update
+  QuestionIndex (page reload required). Documented limitation.
+- **FT-276** Rapid J presses (e.g., 10 in 100ms): each press
+  advances marker by ONE question_stem block; no skipping.
+  High.
+
+## Boundary Tests
+
+- **FT-277** AutoPausePolicy toggled exactly at question_stem
+  block_end moment: race-free per Riverpod state-update model
+  (toggle write happens before state-machine event handler
+  reads).
+- **FT-278** localStorage write fails (quota exceeded, private
+  browsing): policy still works in-memory; warns to console.
+  Documented degradation.
+
+## Permission and Role Tests
+
+- **FT-279** Read-only at runtime — F39 reads from F22 plan.json
+  (immutable) and writes only to localStorage (sandboxed per
+  origin). No global state mutation.
+
+## Integration Tests
+
+- **FT-280** F52 → F22 → F39 chain: a plan.json with 3
+  question_stem blocks (per F52 classifier) drives 3 auto-pauses
+  via F39 state machine. Smoke test on Economy.pdf demo.
+- **FT-281** F35 word-sync hook: J advances the F35 marker AND
+  the F39 QuestionIndex consistently. Both bound to the same
+  block-boundary signal.
+- **FT-282** F38 WCAG keyboard requirement: J/K shortcuts
+  appear in F38's audit checklist with `prefers-reduced-motion`
+  consideration (no animation at jump time).
+
+## Audit and Traceability Tests
+
+- **FT-283** Every auto-pause event logs to corrections.json
+  (or player-event log) with a reference to the
+  question_stem block_id. Reviewer in F50 can replay the
+  pause sequence.
+- **FT-284** Toggle state changes log a timestamp + new value
+  to the player-event log for accommodation-audit purposes.
+
+## Regression Risks
+
+- **R-01** Auto-pause too aggressive on multi-part questions
+  (a/b/c sub-parts inside one question_stem). Mitigation: F52
+  emits ONE block per top-level question; sub-parts share a
+  block. F39 only pauses at block_end. If F52 is later changed
+  to split sub-parts, F39 contract test surfaces the regression.
+- **R-02** F36 settings panel UI conflict if multiple toggles
+  share keyboard shortcuts. Mitigation: F39 reserves J/K
+  exclusively; F36 has no prior J/K binding (verified at
+  implementation time).
+- **R-03** AutoPausePolicy default change (e.g., to OFF) would
+  silently break the Phase-0 success criterion. Mitigation:
+  default-true is documented in F39 design.md DE-05 and
+  asserted in FT-260.
+- **R-04** Cross-page navigation (page N to N+1) must reset
+  QuestionIndex. F39 test asserts; if F35 page-load events
+  change shape, F39 contract test surfaces it.
+
+## Open Questions
+
+- **Q-01** Should `Space` (existing F36 play/pause toggle)
+  ALSO advance to next question_stem when pressed during
+  auto-pause? Currently no — Space resumes; J advances. Two
+  behaviours, one ergonomic question. Defer to UX measurement
+  on real students (cloud research follow-up).
+- **Q-02** Should the auto-pause fade audio out (vs. hard
+  cut)? Hard cut is simpler; fade is gentler. Defer to F36
+  audio-quality work.
+- **Q-03** Should ProgressHint show the question's TEXT (e.g.,
+  "Q3: How much...") instead of just "3 of 12"? Privacy /
+  accommodation question — students may want minimal text.
+  Defer to teacher feedback.

--- a/.workitems/N04-player/F39-pause-after-question/ontology-delta.yaml
+++ b/.workitems/N04-player/F39-pause-after-question/ontology-delta.yaml
@@ -1,0 +1,171 @@
+# Ontology delta — N04/F39 Pause-and-Jump Affordance
+# Authored 2026-05-02 as Phase-0 design backfill (pre-implementation).
+# F39 will introduce Flutter/Dart code under flutter_app/lib/components/player/.
+
+version: 1
+feature_id: N04/F39
+
+modules:
+  - id: MOD-N04-F39-auto-pause-policy
+    name: flutter_app.lib.components.player.auto_pause_policy
+    description: |
+      Riverpod state class. Holds a single boolean `enabled`. Default
+      true (per Q4). Persists in localStorage under
+      tirvi.player.auto_pause_after_question.
+    feature_refs: [N04/F39]
+    bounded_context: player
+    source_path: flutter_app/lib/components/player/auto_pause_policy.dart
+    status: designed
+  - id: MOD-N04-F39-question-index
+    name: flutter_app.lib.components.player.question_index
+    description: |
+      Computes (current, total) of question_stem blocks for the active
+      page. Updates on block-boundary events from F35. Bound to
+      ProgressHint widget via Riverpod.
+    feature_refs: [N04/F39]
+    bounded_context: player
+    source_path: flutter_app/lib/components/player/question_index.dart
+    status: designed
+  - id: MOD-N04-F39-keyboard-handler
+    name: flutter_app.lib.components.player.keyboard_handler  # extension to F36
+    description: |
+      Adds J / K bindings to the F36 keyboard router. J advances
+      marker to next question_stem; K reverses. State-aware
+      (paused stays paused on jump).
+    feature_refs: [N04/F36, N04/F39]
+    bounded_context: player
+    source_path: flutter_app/lib/components/player/keyboard_handler.dart
+    status: designed
+  - id: MOD-N04-F39-progress-hint
+    name: flutter_app.lib.components.player.progress_hint
+    description: |
+      Widget rendering "שאלה N מתוך M" adjacent to play/pause control.
+      aria-live="polite" for screen-reader announcements (per F38
+      WCAG audit).
+    feature_refs: [N04/F39]
+    bounded_context: player
+    source_path: flutter_app/lib/components/player/progress_hint.dart
+    status: designed
+
+services: []
+ports: []
+adapters: []
+
+classes:
+  - id: CLS-N04-F39-AutoPausePolicy
+    name: AutoPausePolicy
+    description: |
+      Riverpod-managed state class. Single boolean field `enabled`
+      (default true). Persisted via localStorage adapter.
+    feature_refs: [N04/F39]
+    bounded_context: player
+    module_ref: MOD-N04-F39-auto-pause-policy
+    source_path: flutter_app/lib/components/player/auto_pause_policy.dart
+    status: designed
+  - id: CLS-N04-F39-QuestionIndex
+    name: QuestionIndex
+    description: |
+      Frozen value object — `(current: int, total: int)`. Constructed
+      via QuestionIndex.fromPlan(plan); updated on block-boundary
+      events.
+    feature_refs: [N04/F39]
+    bounded_context: player
+    module_ref: MOD-N04-F39-question-index
+    source_path: flutter_app/lib/components/player/question_index.dart
+    status: designed
+
+functions:
+  - id: FN-N04-F39-on-block-end
+    name: onBlockEnd
+    description: |
+      Player state-machine handler. On block_end event, if the
+      finished block_kind == question_stem AND
+      AutoPausePolicy.enabled, transition to paused state.
+    feature_refs: [N04/F36, N04/F39]
+    bounded_context: player
+    module_ref: MOD-N04-F39-auto-pause-policy
+    source_path: flutter_app/lib/components/player/state_machine.dart
+    status: designed
+  - id: FN-N04-F39-jump-next-question
+    name: jumpToNextQuestion
+    description: |
+      Advances the F35 marker to the start of the next question_stem
+      block. Audio resumes from that point IF playing; remains
+      paused IF paused.
+    feature_refs: [N04/F39]
+    bounded_context: player
+    module_ref: MOD-N04-F39-keyboard-handler
+    source_path: flutter_app/lib/components/player/keyboard_handler.dart
+    status: designed
+  - id: FN-N04-F39-jump-previous-question
+    name: jumpToPreviousQuestion
+    description: |
+      Reverses to the start of the previous question_stem block.
+      Symmetric to jumpToNextQuestion.
+    feature_refs: [N04/F39]
+    bounded_context: player
+    module_ref: MOD-N04-F39-keyboard-handler
+    source_path: flutter_app/lib/components/player/keyboard_handler.dart
+    status: designed
+
+constants:
+  - id: CONST-N04-F39-localstorage-key
+    name: tirvi.player.auto_pause_after_question
+    description: |
+      localStorage key (string) for AutoPausePolicy persistence.
+      Reserved per F32 localStorage convention.
+    feature_refs: [N04/F32, N04/F39]
+    bounded_context: player
+    source_path: flutter_app/lib/components/player/auto_pause_policy.dart
+    status: designed
+
+adr_decisions:
+  - id: adr:041
+    name: red-line decision register
+    description: F39 entry — row #5 (auto-pause at question_stem end ALLOW; auto-pause is "extra time wired into the medium" rather than exam modification, aligning with MoE Level 1).
+    feature_refs: [N04/F39]
+    status: proposed
+
+tasks:
+  - id: task:N04/F39/T-01
+    name: auto-pause-policy-class
+    feature_refs: [N04/F39]
+    spec_refs: [spec:N04/F39/DE-01, spec:N04/F39/DE-05]
+    test_path: flutter_app/test/player/auto_pause_policy_test.dart
+    status: designed
+  - id: task:N04/F39/T-02
+    name: question-index-computation
+    feature_refs: [N04/F39]
+    spec_refs: [spec:N04/F39/DE-02]
+    test_path: flutter_app/test/player/question_index_test.dart
+    status: designed
+  - id: task:N04/F39/T-03
+    name: state-machine-auto-pause
+    feature_refs: [N04/F36, N04/F39]
+    spec_refs: [spec:N04/F39/DE-01]
+    test_path: flutter_app/test/player/state_machine_auto_pause_test.dart
+    status: designed
+  - id: task:N04/F39/T-04
+    name: jk-keyboard-handlers
+    feature_refs: [N04/F36, N04/F39]
+    spec_refs: [spec:N04/F39/DE-03, spec:N04/F39/DE-06]
+    test_path: flutter_app/test/player/keyboard_jk_test.dart
+    status: designed
+  - id: task:N04/F39/T-05
+    name: progress-hint-widget
+    feature_refs: [N04/F39]
+    spec_refs: [spec:N04/F39/DE-04]
+    test_path: flutter_app/test/player/progress_hint_widget_test.dart
+    status: designed
+  - id: task:N04/F39/T-06
+    name: settings-panel-toggle
+    feature_refs: [N04/F36, N04/F39]
+    spec_refs: [spec:N04/F39/DE-05]
+    test_path: flutter_app/test/player/auto_pause_toggle_widget_test.dart
+    status: designed
+  - id: task:N04/F39/T-07
+    name: economy-pdf-pause-jump-integration
+    feature_refs: [N02/F52, N04/F39]
+    spec_refs: [spec:N04/F39/DE-01..DE-06]
+    test_path: flutter_app/integration_test/economy_pdf_pause_jump_test.dart
+    status: designed

--- a/docs/research/sdlc-shortcut-postmortem-phase0.md
+++ b/docs/research/sdlc-shortcut-postmortem-phase0.md
@@ -1,0 +1,152 @@
+---
+title: SDLC shortcut postmortem — Phase 0 reading-disability features
+date: 2026-05-02
+status: published
+authors: jbellish + Claude Opus 4.7 (CLI)
+related_prs:
+  - "#29 (F51 homograph context-rules)"
+  - "#33 (Phase-0 scaffold ADR-041 + workitems)"
+  - "#34 (F52 block-kind taxonomy)"
+  - "#35 (F53 clause-split SSML chunker — F53 backfill on this branch)"
+  - "#36 (this — F51/F52/F39 backfill + methodology alignment)"
+related_adrs:
+  - ADR-041 (red-line decision register)
+related_rules:
+  - .claude/rules/workflow.md (amended in PR #36 to make 3 artifacts mandatory)
+---
+
+# Phase-0 SDLC shortcut — what happened, what we did about it
+
+## TL;DR
+
+Phase 0 (F51 homograph context-rules + F52 block-kind taxonomy + F53
+clause-split chunker + F39 player pause-after-question) shipped with
+a **reduced design ceremony** compared to the project's documented
+SDLC. Specifically, three artifacts that F21 set as precedent were
+omitted from the F51/F52/F53/F39 workitem folders:
+`functional-test-plan.md`, `behavioural-test-plan.md`,
+`ontology-delta.yaml`.
+
+The shortcut was acknowledged at PR #35 review; the user
+(jbellish) elected **option A** of three remediation paths: don't
+mechanically backfill the meeting-room / review / STD artifacts that
+are most ceremony-heavy AND least useful in retrospect, but DO
+mandate the three foundational design artifacts for every feature
+going forward and backfill them across F51/F52/F53/F39.
+
+This document records the decision so it shows up in `git log` /
+`docs/research/` rather than dissolving into a memory the next
+maintainer has to reconstruct.
+
+## What was skipped vs. what was kept
+
+| Artifact                          | F21 (precedent) | F51 (merged) | F52 (merged) | F53 (PR #35) | F39 (scaffold) |
+|-----------------------------------|:---------------:|:------------:|:------------:|:------------:|:--------------:|
+| ADR (binding scope)               | none/n.a.        | ADR-038      | ADR-041      | ADR-041      | ADR-041        |
+| `design.md`                       | ✅              | ✅            | ✅            | ✅            | ✅              |
+| `tasks.md`                        | ✅              | ✅            | ✅            | ✅            | ✅              |
+| `user_stories.md`                 | ✅              | ✅            | ✅            | ✅            | ✅              |
+| `traceability.yaml`               | ✅              | ✅            | ✅            | ✅            | ✅              |
+| **`functional-test-plan.md`**     | ✅              | ❌ → backfilled | ❌ → backfilled | ❌ → backfilled | ❌ → backfilled |
+| **`behavioural-test-plan.md`**    | ✅              | ❌ → backfilled | ❌ → backfilled | ❌ → backfilled | ❌ → backfilled |
+| **`ontology-delta.yaml`**         | ✅              | ❌ → backfilled | ❌ → backfilled | ❌ → backfilled | ❌ → backfilled |
+| `meeting-room/` (synthesis)       | ✅              | ❌            | ❌            | ❌            | ❌              |
+| `review/R1/R2/R3` trails          | ✅              | ❌            | ❌            | ❌            | ❌              |
+| STD.md (`@test-design`)           | (varies)        | ❌            | ❌            | ❌            | ❌              |
+
+The three rows in **bold** are now mandatory for every workitem (per
+the workflow.md amendment in PR #36). The four rows below them
+(meeting-room, review, STD) stay deferred for Phase 0 — see "What
+remains skipped" below.
+
+## What did happen at design time (why it wasn't catastrophic)
+
+The design ceremony was reduced, not absent. What stood in for the
+missing artifacts:
+
+- **PR #30 (research roadmap)** — multi-source synthesis of the 11
+  user-stated reading-disability requirements + 20-row red-line
+  decision register + priority-ordered workitem list + Phase 0
+  recommendation (F52 + F53 + F39). Reviewer-approved via 7 explicit
+  questions.
+- **ADR-041** — codified the 20-row red-line register as a binding
+  ADR before any feature design touched code. Filed first per Q7
+  reviewer answer.
+- **PR #33 (scaffold)** — populated each workitem's `design.md`,
+  `tasks.md`, `user_stories.md`, `traceability.yaml` with non-trivial
+  content drawn from the roadmap. design.md per feature included
+  problem statement, dependencies, interfaces, design elements,
+  out-of-scope, and risks.
+- **High test coverage** — F52 ships at 30/30 strict on its synthetic
+  corpus; F53 ships at 22/22; F51 was already at 29/31 (with two
+  documented xfails). The full test suite stayed at 0 regressions
+  through every Phase-0 PR.
+
+The three foundational artifacts, when backfilled now, document
+*what already exists in the code and the reviewer-approved roadmap*.
+They are not adding new design intent — they are pulling existing
+intent into the canonical workitem shape so a future maintainer
+finds it where they expect to.
+
+## What remains skipped (deliberate)
+
+| Artifact                                 | Why deferred                                                                                                           |
+|------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `meeting-room/` synthesis trail           | The roadmap PR #30 + the user-reviewer Q&A on PR #30 + the in-conversation reviewer pass acted as the synthesis. Filing fresh meeting-room artifacts retroactively would be performative — no real synthesis occurred at meeting-room time. |
+| `review/R1/R2/R3` rounds                  | F52 and F53 are already merged with high test coverage and zero regressions. Running an adversary review against shipped, tested code is unlikely to surface anything actionable; "concerns" filed retroactively don't get fixed. F39 has no code yet — its review will happen forward, not backfilled. |
+| STD.md (`@test-design`)                   | Functional + behavioural test plans (now backfilled) cover the WHAT-to-test layer. STD.md adds an epic-level view + traceability test-entry shape that F21 has but is genuinely heavyweight. Defer to Phase-1+ when multi-feature epics need it.    |
+
+The decision is honest, not lazy: **adding paper that nobody reads
+or acts on is worse than admitting the work was light and codifying
+the rule going forward.**
+
+## What changes for Phase 1+ (F54, F40, F41, F55, N05/F51-bench)
+
+Going forward, every new workitem MUST include:
+
+- The three previously-mandatory artifacts (`design.md`,
+  `tasks.md`, `user_stories.md`, `traceability.yaml`).
+- The three NEWLY-mandatory artifacts (`functional-test-plan.md`,
+  `behavioural-test-plan.md`, `ontology-delta.yaml`).
+
+For features that route through `@biz-functional-design` →
+`@sw-designpipeline`, the first two of the new three are produced
+automatically by the biz half. For features that don't have a biz
+corpus (most internal-tooling and player work), the maintainer
+authors them at design time, not at backfill time.
+
+The workflow.md amendment in PR #36 makes this load-bearing. A
+future PR that omits any of these artifacts should be flagged at
+review.
+
+## Lessons for the agent (Claude Code) and the user
+
+1. **"Implement as new feature in existing epics" is ambiguous.** It
+   could mean "use the full pipeline" or "scaffold a workitem and
+   ship". I picked the lighter reading; the user accepted at "go"
+   but flagged it later. Clearer signal next time: when a request
+   crosses the 3-module / non-trivial threshold from
+   `workflow.md`, the agent SHOULD ask which design lane to take
+   (full / lite / scaffold-only) rather than infer.
+2. **The merged research roadmap is a strong design artifact.** It
+   carried the per-feature design intent through reviewer Q&A. The
+   gap was not "no design happened"; the gap was "the canonical
+   workitem-shape artifacts were not authored". The fix is the
+   shape, not the substance.
+3. **High test coverage doesn't substitute for design ceremony.**
+   F52's 30/30 corpus and F53's 22/22 corpus catch implementation
+   bugs, not design errors. The functional-test-plan + behavioural-
+   test-plan ARE the design-error catchers. They get authored
+   even when the implementation is already green.
+4. **Retrospective adversary review has diminishing returns.** If
+   the design ceremony was reduced, file the postmortem honestly
+   and tighten the rule. Don't pantomime the missing rounds against
+   shipped code.
+
+## Sign-off
+
+This document, the workflow.md amendment, and the three backfilled
+artifacts per feature are the explicit closure of the Phase-0 design-
+ceremony gap. PR #36 is the carrier; F53's same-three artifacts
+ride on PR #35. Subsequent feature PRs MUST include all seven
+workitem files at merge time.


### PR DESCRIPTION
## Summary

Closes the Phase-0 design-ceremony gap that surfaced during PR #35 review. Three foundational design artifacts (`functional-test-plan.md`, `behavioural-test-plan.md`, `ontology-delta.yaml`) — which F21 set as precedent and which the project's workflow assumed every workitem would carry — were missing from F51 (merged in PR #29), F52 (merged in PR #34), F53 (PR #35 in flight), and F39 (scaffold in PR #33). This PR backfills all four AND amends `workflow.md` to make the three artifacts mandatory going forward.

## Closes the gap

| Feature | Path | Status post-merge |
|---------|------|-------------------|
| F51 (homograph context-rules) | `.workitems/N02-hebrew-interpretation/F51-homograph-context-rules/` | 3 artifacts added |
| F52 (block-kind taxonomy) | `.workitems/N02-hebrew-interpretation/F52-block-kind-taxonomy/` | 3 artifacts added |
| F39 (player pause-and-jump) | `.workitems/N04-player/F39-pause-after-question/` | 3 artifacts added |
| F53 (clause-split chunker) | (NOT in this PR — backfilled on PR #35 directly) | already pushed to PR #35 branch |

## Methodology amendment

`.claude/rules/workflow.md` Step 2 (Design) gains a new "Mandatory workitem artifacts" subsection listing all 7 required files (the 4 already-mandatory + the 3 newly-mandatory). F21 named as the canonical template. Future PRs that omit any of the 7 should be flagged at review.

## Postmortem

`docs/research/sdlc-shortcut-postmortem-phase0.md` (~180 lines) — honest record of:
- What was skipped vs. what was kept (table per feature)
- What stood in for the missing artifacts (PR #30 roadmap, ADR-041, PR #33 scaffold, high test coverage)
- What stays skipped explicitly (`meeting-room/`, `review/R1-R3`, `STD.md`) — retrospective adversary review on shipped tested code has diminishing returns; the right move is the rule going forward, not pantomime
- 4 lessons (clearer design-lane signals, roadmap-as-design-artifact, test-coverage-doesn't-substitute, retro-review diminishing returns)

## Test plan

- [x] `tests/` full suite — **980 passed, 92 skipped, 2 xfailed** (this branch is off main pre-PR-#35; numbers will rise to 1024 once F53 lands)
- [x] No production code touched — pure documentation backfill
- [x] All ontology-delta.yaml files validate as YAML (loadable with `yaml.safe_load`)
- [x] Each backfilled feature now matches F21's precedent shape
- [ ] Reviewer to spot-check the FT/BT scenario coverage against the actual implementations of F51/F52/F53
- [ ] Reviewer to confirm the workflow.md amendment is the right governance level (rule vs. ADR)

## Merge order

`PR #35 (F53 with backfill)` → `PR #36 (this — F51/F52/F39 backfill + methodology + postmortem)` → forward.

The two PRs are doc-only and disjoint at the file level (PR #35 touches F53's workitem dir; this PR touches F51/F52/F39). No conflicts expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
