### PR TITLE
chore(harness): make rules language-agnostic; fix tirvi-specific lie

### DIFF
--- a/.claude/rules/coding-standards.md
+++ b/.claude/rules/coding-standards.md
@@ -1,105 +1,193 @@
 ---
-paths:
-  - "cmd/**/*.go"
-  - "pkg/**/*.go"
-  - "internal/**/*.go"
-  - "flutter_app/lib/**/*.dart"
-  - "scripts/**/*.py"
-  - "proto/**/*.proto"
+# Universal coding standards. Per-language sections are TEMPLATES — they
+# apply only to languages the hosting project has actually enabled in its
+# CLAUDE.md or settings. The harness must not assume a project uses a
+# given language; assumptions cause stack-mismatch design errors (see
+# docs/research/sdlc-shortcut-postmortem-phase0.md §lesson 5).
 ---
 
 # Coding Standards
 
-## Go Standards
+This file is **language-agnostic**. The Universal Rules apply to every
+project that loads the harness. The per-language sections below are
+templates the agent reads ONLY when the hosting project's CLAUDE.md
+declares the corresponding language as in use. The harness itself
+makes no assumption about which languages a given project uses.
 
-### Style
-1. `gofmt` is non-negotiable — all Go code must be formatted
-2. Use `golangci-lint` with project config (`.golangci.yml`)
-3. Import order: stdlib → third-party → internal (enforced by goimports)
-4. Exported functions get doc comments; unexported can skip if self-evident
-5. Errors are values — return `error`, don't panic. Wrap with `fmt.Errorf("context: %w", err)`
-6. Use struct literals with field names: `Config{Port: 8080}`, not `Config{8080}`
+## Universal Rules (apply to all projects, all languages)
 
-### Concurrency
-7. Goroutines must have clear ownership and shutdown path (use `context.Context`)
-8. Channels over mutexes when modeling communication between goroutines
-9. Never launch a goroutine without a way to stop it (context cancellation or done channel)
-10. Use `errgroup` for concurrent operations that need error propagation
+1. **Cyclomatic complexity ≤ 5** per function. Refactor when growing.
+   The `check-complexity.sh` hook enforces > 7 as a hard block; 6-7 is
+   a soft block (must refactor before commit).
+2. **Tests before implementation (TDD)** for all production code. See
+   `.claude/rules/tdd-rules.md`.
+3. **No secrets in code** — environment variables or secret manager
+   only. The `block-dangerous-commands.sh` hook screens commits.
+4. **All public APIs documented** — language-appropriate doc comments
+   (Go doc comments, JSDoc/TSDoc, Python docstrings, Dart doc comments,
+   etc.).
+5. **Format-on-save is non-negotiable** — every project enables a
+   formatter for every language it ships. The agent must not commit
+   un-formatted code.
+6. **No untyped public surfaces** — every public function or method
+   has type annotations / signatures. Strict-mode tooling encouraged.
+7. **Pure-function preference** — push side-effects to the boundary
+   (adapters, IO, mutation), keep core logic deterministic and
+   testable.
 
-### Architecture
-11. `cmd/` packages: only `main()` + flag parsing + dependency wiring
-12. `pkg/core/`: shared interfaces and domain types — no external service dependencies
-13. `internal/`: implementation details not exported to other modules
-14. Interfaces at consumer side (accept interfaces, return structs)
-15. Repository pattern for all database access — no raw SQL in handlers
+## Project-language declaration (read this before per-language rules)
 
-### Testing
-16. Table-driven tests with `t.Run()` subtests
-17. Use `testify/assert` or stdlib — be consistent within a package
-18. Mocks via interfaces, not monkey-patching
-19. `_test.go` files colocated with source
+The hosting project declares its languages and code paths via:
 
-## Dart/Flutter Standards
+- The frontmatter / "Project Conventions" section of its `CLAUDE.md`.
+- A per-project `coding-standards-overlay.md` if the project wants
+  to override or extend universal rules.
+- The actual repo layout (which the agent inspects via `ls` /
+  `Glob` before authoring per-language artifacts).
 
-### Style
-20. `dart format` is non-negotiable — all Dart code must be formatted
-21. `flutter analyze` must pass with zero issues
-22. Follow Effective Dart conventions (naming, documentation, usage, design)
-23. Use `const` constructors wherever possible for widget performance
-24. Prefer composition over inheritance for widgets
+**The agent MUST inspect the project's actual repo before quoting any
+per-language rule from this file.** Pattern-matching from the harness
+to a presumed language has caused real design errors; see the
+postmortem for the F39 case study.
 
-### State Management
-25. Riverpod or Bloc — one pattern per project, do not mix
-26. Business logic in providers/blocs, not in widgets
-27. Widgets are pure UI — no API calls, no database access
-28. Use `AsyncValue` (Riverpod) or state classes (Bloc) for loading/error/data
+## Per-language sections (templates — apply only when project enables)
 
-### Architecture
-29. Feature-first folder structure: `lib/features/<name>/` *(N05 exemption: an imported upstream Flutter app retains its source flat `lib/{pages,data,shell,components,theme}` layout pending post-N08 consolidation — see ADR-014. The pre-existing F03 scaffold contained only `.gitkeep` placeholders, so the exemption clobbers nothing real.)*
-30. Each feature: `data/` (repositories, models), `domain/` (entities, use cases), `presentation/` (widgets, providers) *(N05 exemption applies)*
-31. gRPC client code is generated — never hand-write protobuf serialization
-32. Local cache via Drift (SQLite) for offline support
+### Go (when the project ships Go code)
 
-### Testing
-33. Widget tests with `testWidgets()` for UI behavior
-34. Unit tests for providers/blocs/use cases
-35. Golden tests for pixel-perfect verification of key screens
-36. Integration tests for critical user flows
+#### Style
+- `gofmt` is non-negotiable — all Go code must be formatted.
+- Use `golangci-lint` with project config (`.golangci.yml`).
+- Import order: stdlib → third-party → internal (enforced by goimports).
+- Exported functions get doc comments; unexported can skip if
+  self-evident.
+- Errors are values — return `error`, don't panic. Wrap with
+  `fmt.Errorf("context: %w", err)`.
+- Use struct literals with field names: `Config{Port: 8080}`, not
+  `Config{8080}`.
 
-## Python Standards (Tooling Only)
+#### Concurrency
+- Goroutines must have clear ownership and shutdown path
+  (use `context.Context`).
+- Channels over mutexes when modeling communication between
+  goroutines.
+- Never launch a goroutine without a way to stop it (context
+  cancellation or done channel).
+- Use `errgroup` for concurrent operations that need error propagation.
 
-Python is used for dev tooling, not the product app. Keep it simple.
+#### Architecture
+- `cmd/` packages: only `main()` + flag parsing + dependency wiring.
+- `pkg/core/`: shared interfaces and domain types — no external
+  service dependencies.
+- `internal/`: implementation details not exported to other modules.
+- Interfaces at consumer side (accept interfaces, return structs).
+- Repository pattern for all database access — no raw SQL in
+  handlers.
 
-### Style
-37. ruff for lint + format (line-length=100)
-38. Type hints on all function signatures
-39. f-strings for formatting
-40. `Path` objects over string paths
+#### Testing
+- Table-driven tests with `t.Run()` subtests.
+- Use `testify/assert` or stdlib — be consistent within a package.
+- Mocks via interfaces, not monkey-patching.
+- `_test.go` files colocated with source.
 
-### Patterns
-41. Use `async def` for I/O-bound functions in daemon scripts
-42. `yaml.safe_load()` only, never `yaml.load()`
-43. Parameterized queries (`?` placeholders), never string formatting for SQL
-44. Array form for subprocess (`["cmd", "arg"]`), never `shell=True`
-45. Always set timeout on subprocess and async operations
+### Dart / Flutter (when the project ships a Flutter app)
 
-## Protobuf Standards
+#### Style
+- `dart format` is non-negotiable — all Dart code must be formatted.
+- `flutter analyze` must pass with zero issues.
+- Follow Effective Dart conventions (naming, documentation, usage,
+  design).
+- Use `const` constructors wherever possible for widget performance.
+- Prefer composition over inheritance for widgets.
 
-46. One service per `.proto` file, matching the Go package name
-47. Use `buf lint` — enforces naming, package structure, field numbering
-48. `buf breaking` in CI — no backwards-incompatible changes without versioning.
-    The `FILE` ruleset (strictest) rejects field deletion even with `reserved`
-    clauses — only `WIRE` / `WIRE_JSON` treat `reserved` as equivalent to
-    presence. When evolving a single-field stub response into a typed shape,
-    preserve the original field under its original field number as a
-    doc-commented `buf-compat keep-alive`; do not delete it or switch numbers.
-    Add typed fields alongside using new field numbers.
-49. Field names: `snake_case`. Message names: `PascalCase`. Enum values: `UPPER_SNAKE_CASE`
-50. Every message field gets a comment if its purpose isn't obvious from the name
+#### State Management
+- Riverpod or Bloc — one pattern per project, do not mix.
+- Business logic in providers/blocs, not in widgets.
+- Widgets are pure UI — no API calls, no database access.
+- Use `AsyncValue` (Riverpod) or state classes (Bloc) for
+  loading/error/data.
 
-## Cross-Language Rules
+#### Architecture
+- Feature-first folder structure: `lib/features/<name>/`. Project may
+  declare layout exemptions in its CLAUDE.md (e.g., a project that
+  imports an upstream Flutter app with a flat layout).
+- Each feature: `data/` (repositories, models), `domain/` (entities,
+  use cases), `presentation/` (widgets, providers).
+- gRPC client code is generated — never hand-write protobuf
+  serialization.
+- Local cache via Drift (SQLite) for offline support, when offline
+  is in scope.
 
-51. Cyclomatic complexity: CC <= 5 per function (all languages)
-52. No secrets in code — environment variables or secret manager only
-53. All public APIs documented (Go doc comments, Dart doc comments, Python docstrings)
-54. Tests before implementation (TDD) for all production code
+#### Testing
+- Widget tests with `testWidgets()` for UI behavior.
+- Unit tests for providers/blocs/use cases.
+- Golden tests for pixel-perfect verification of key screens.
+- Integration tests for critical user flows.
+
+### Python (when the project ships Python code)
+
+#### Style
+- `ruff` for lint + format (line-length per project config).
+- Type hints on all function signatures.
+- f-strings for formatting.
+- `Path` objects over string paths.
+
+#### Patterns
+- Use `async def` for I/O-bound functions in daemon scripts.
+- `yaml.safe_load()` only, never `yaml.load()`.
+- Parameterized queries (`?` placeholders), never string formatting
+  for SQL.
+- Array form for subprocess (`["cmd", "arg"]`), never `shell=True`.
+- Always set timeout on subprocess and async operations.
+
+### TypeScript / JavaScript (when the project ships browser or Node code)
+
+#### Style
+- A formatter (Prettier or biome) is non-negotiable; project picks one.
+- A type checker (TypeScript strict mode, or `// @ts-check` on JS)
+  applies to every public surface.
+- ESM modules over CommonJS for new code.
+- `const` by default; `let` only when reassignment is needed; `var`
+  never.
+
+#### Patterns
+- No business logic in event handlers — extract to pure functions and
+  unit-test those. Handlers are wiring only.
+- DOM access lives at the boundary; core logic must be testable
+  without a browser (jsdom, vitest's default test environment).
+- No global state mutation — module-scoped state with explicit
+  getters/setters.
+
+#### Testing
+- vitest (or Jest) for unit + module tests.
+- Component / DOM tests via vitest + jsdom or testing-library.
+- Avoid e2e for unit-test scope; reserve Playwright for cross-page
+  flows.
+
+### Protobuf (when the project ships .proto files)
+
+- One service per `.proto` file.
+- Use `buf lint` — enforces naming, package structure, field
+  numbering.
+- `buf breaking` in CI — no backwards-incompatible changes without
+  versioning. The `FILE` ruleset (strictest) rejects field deletion
+  even with `reserved` clauses; only `WIRE` / `WIRE_JSON` treat
+  `reserved` as equivalent to presence. When evolving a single-field
+  stub response into a typed shape, preserve the original field
+  under its original field number as a doc-commented `buf-compat
+  keep-alive`; do not delete it or switch numbers. Add typed fields
+  alongside using new field numbers.
+- Field names: `snake_case`. Message names: `PascalCase`. Enum
+  values: `UPPER_SNAKE_CASE`.
+- Every message field gets a comment if its purpose isn't obvious
+  from the name.
+
+## Adding a new language section
+
+1. Read the project's CLAUDE.md to confirm the language is actually
+   in use.
+2. Append a new `### <Language>` section under "Per-language
+   sections", mirroring the existing structure (Style / Patterns /
+   Testing as applicable).
+3. Cross-reference any project-specific overlay file.
+4. **Do NOT add per-language assumptions to the Universal Rules
+   section** — that's the path that creates harness-meta drift.

--- a/.claude/rules/tdd-rules.md
+++ b/.claude/rules/tdd-rules.md
@@ -1,125 +1,158 @@
 ---
-# Unconditional — always loaded
+# Unconditional — always loaded. Language-agnostic. Per-language TDD
+# skills (`@tdd-go`, `@tdd-flutter`, `@tdd-python`, …) own concrete
+# path matrices and command examples; this file owns the universal
+# discipline.
 ---
 
 # TDD Discipline
 
+This rule is **language-agnostic**. The principles below apply to every
+project, every language. The harness ships per-language TDD skills
+(under `.claude/skills/tdd-*`) that bind these principles to concrete
+file paths and test runners. The hosting project's `CLAUDE.md`
+declares which languages apply; the agent must inspect the actual
+repository before invoking any per-language path matrix from this
+file or its associated skills.
+
 ## TDD Entry Point and Mode Selection
 
-Entry point: `/tdd` (router). Validates prerequisites, detects language,
-delegates to `@tdd-go` or `@tdd-flutter`.
+Entry point: **`/tdd`** (router). The router:
 
-Each language skill evaluates the task against its own decision table and
-prompts: "I recommend {BUNDLED|STRICT} because {reason}. Approve or change?"
-Use `--accept-all` to skip the prompt. See `@tdd-go` and `@tdd-flutter`
-for language-specific decision tables.
+1. Validates prerequisites (workitem exists, design artifacts in
+   place per `.claude/rules/workflow.md`, current task is the next
+   unchecked one in `tasks.md`).
+2. Detects the language(s) at play by inspecting the task's
+   `test_file` path and the project's CLAUDE.md.
+3. Delegates to the matching per-language TDD skill (e.g.,
+   `@tdd-go`, `@tdd-flutter`, `@tdd-python`). The harness must NOT
+   hard-code which delegation is correct for any given project.
+
+Each per-language TDD skill evaluates the task against its own
+decision table and prompts: *"I recommend {BUNDLED|STRICT} because
+{reason}. Approve or change?"* Use `--accept-all` to skip the
+prompt. See the per-language skill SKILL.md files for their
+decision tables.
 
 ### Bundled Mode (default)
 
-Per task: write ALL tests first, then write ALL code to pass, then refactor.
-Test revision pass after GREEN if any test needed signature changes.
+Per task: write ALL tests first, then write ALL code to pass, then
+refactor. Test revision pass after GREEN if any test needed signature
+changes.
 
 ### Strict Mode
 
-Per task: write ONE failing test, write minimum code to pass, optionally
-refactor. Repeat for each test. Used for tasks with unknown solution shape.
+Per task: write ONE failing test, write minimum code to pass,
+optionally refactor. Repeat for each test. Used for tasks with
+unknown solution shape.
 
-## Core TDD Principles
+## Core TDD Principles (universal)
 
-1. Do not write production code unless it makes a failing test pass
-2. Write tests before implementation (bundled or one-at-a-time per mode)
-3. Do not write more production code than sufficient to pass the tests
+1. Do not write production code unless it makes a failing test
+   pass.
+2. Write tests before implementation (bundled or one-at-a-time per
+   mode).
+3. Do not write more production code than sufficient to pass the
+   tests.
+4. Per-task `tasks.md` markers (`- [ ] **T-NN done**` →
+   `- [x] **T-NN done**`) flip atomically with the GREEN commit per
+   `task-format.md`.
 
-## When to Use TDD
+## When to Use TDD (universal)
 
-### TDD — for deterministic, testable code:
-- Go core engine: config parsing, dispatch logic, repository methods, domain models
-- Go BFF: request validation, response shaping, auth middleware
-- Go daemons: state management, priority classification, rule-based processing
-- Flutter: providers/blocs, use cases, data transformations, repository adapters
-- Python tooling: data transformation, calculation logic, API response parsing
+### TDD — for deterministic, testable code
 
-**Test with:**
-- Go: `go test` with table-driven tests and fakes from `pkg/testutil/fakes/`
-- Flutter: `flutter test` with widget tests and provider mocks
-- Python: `pytest` with `tmp_path` fixtures
+Anything that's a pure function, a state machine, a parser, a
+formatter, a configuration loader, a request validator, a domain
+model. Per-language TDD skills enumerate concrete examples for the
+languages they cover.
 
-### Functional/Smoke/Regression Tests — written separately:
-- Use `@test-design` to produce STD.md + traceability.yaml (WHAT to test).
-  When `@biz-functional-design` has run for the feature (presence of
-  `functional-test-plan.md`), test-design SYNTHESISES from biz plans
-  rather than generating from stories alone. See ADR-013.
-- Use `@test-mock-registry` to generate shared fakes from port interfaces
-- Use `@test-functional` to write FUNC/SMOKE/REG code (Chicago-school)
-- TDD skills handle unit tests only (per-task, from tasks.md)
+### Functional / Smoke / Regression tests — written separately
 
-### Traceability schema (ADR-013):
-The per-feature `traceability.yaml` schema is forward-compatible. Existing
-`acm_nodes`, `acm_edges`, `de_to_hld`, `story_to_prd`, `task_to_de`,
-`ac_to_story` fields are unchanged. New optional fields added by the biz/sw
-split: `biz_source.{functional_test_plan_path, behavioural_test_plan_path,
-corpus_e_id, imported_at, source_sha}`, `ontology_refs[]` (refs to
-`ontology/*.yaml` node IDs), and `tests[].{ontology_id, test_path, status}`
-(execution state filled at TDD time). Skills that ignore the new fields
-continue to work; TDD skills SHOULD update `tests[].status` as code lands.
+- Use `@test-design` to produce STD.md + traceability.yaml (defines
+  WHAT to test). When `@biz-functional-design` has run for the
+  feature (presence of `functional-test-plan.md`), test-design
+  SYNTHESISES from biz plans rather than generating from stories
+  alone. See ADR-013.
+- Use `@test-mock-registry` to generate shared fakes from port
+  interfaces.
+- Use `@test-functional` to write FUNC/SMOKE/REG code (Chicago-
+  school).
+- Per-language TDD skills handle UNIT tests only (per-task, from
+  tasks.md); functional tests are the language-agnostic concern of
+  `@test-functional`.
 
-### Characterization Tests — for existing untested code:
-- Capture current behavior before refactoring
-- Pin external API interaction patterns
-- Document implicit contracts between components
+### Traceability schema (ADR-013)
 
-## Three-Agent Role Separation
+The per-feature `traceability.yaml` schema is forward-compatible.
+Existing `acm_nodes`, `acm_edges`, `de_to_hld`, `story_to_prd`,
+`task_to_de`, `ac_to_story` fields are unchanged. New optional
+fields added by the biz/sw split: `biz_source.{functional_test_plan_path,
+behavioural_test_plan_path, corpus_e_id, imported_at, source_sha}`,
+`ontology_refs[]` (refs to `ontology/*.yaml` node IDs), and
+`tests[].{ontology_id, test_path, status}` (execution state filled
+at TDD time). Skills that ignore the new fields continue to work;
+TDD skills SHOULD update `tests[].status` as code lands.
 
-During TDD sessions (when `/tmp/ba-tdd-markers/<hash>` exists):
+### Characterization Tests — for existing untested code
 
-### Go
-| Agent | Phase | Can Edit | Cannot Edit |
-|-------|-------|----------|-------------|
-| tdd-test-writer | RED | `*_test.go` | `*.go` (non-test) |
-| tdd-code-writer | GREEN | `*.go` (non-test) | `*_test.go` |
-| tdd-refactorer | REFACTOR | both | no new behavior |
-| lead | coordination | no `.go` files | all `.go` |
+- Capture current behavior before refactoring.
+- Pin external API interaction patterns.
+- Document implicit contracts between components.
 
-### Flutter/Dart
-| Agent | Phase | Can Edit | Cannot Edit |
-|-------|-------|----------|-------------|
-| tdd-test-writer | RED | `flutter_app/test/**` | `flutter_app/lib/**` |
-| tdd-code-writer | GREEN | `flutter_app/lib/**` | `flutter_app/test/**` |
-| tdd-refactorer | REFACTOR | both | no new behavior |
-| lead | coordination | no `.dart` files | all `.dart` |
+## Three-Agent Role Separation (universal pattern)
 
-### Python (tooling)
-| Agent | Phase | Can Edit | Cannot Edit |
-|-------|-------|----------|-------------|
-| tdd-test-writer | RED | `tests/**/*.py` | `scripts/**/*.py` |
-| tdd-code-writer | GREEN | `scripts/**/*.py` | `tests/**/*.py` |
-| tdd-refactorer | REFACTOR | both | no new behavior |
-| lead | coordination | no `.py` files | all `.py` |
+During TDD sessions (when `/tmp/ba-tdd-markers/<hash>` exists), the
+harness enforces a three-agent split. The principle is universal;
+the per-language path matrix is owned by the corresponding TDD
+skill. Generic shape:
 
-## Test Commands
+| Agent           | Phase    | Can edit                         | Cannot edit                    |
+|-----------------|----------|----------------------------------|--------------------------------|
+| tdd-test-writer | RED      | test files (per language convention) | non-test source files       |
+| tdd-code-writer | GREEN    | non-test source files            | test files                     |
+| tdd-refactorer  | REFACTOR | both                             | no new behavior                |
+| lead            | coordination | no source files in this language | all source files in this language |
+
+**Per-language path matrices live in the matching TDD skill's
+SKILL.md** (e.g., `.claude/skills/tdd-go/SKILL.md`,
+`.claude/skills/tdd-flutter/SKILL.md`, `.claude/skills/tdd-python/SKILL.md`).
+The `enforce-tdd-separation.sh` hook reads the marker file and
+delegates path-validation to the active language's matrix.
+
+## Test Commands (per the language's TDD skill, NOT this rule)
+
+This rule does NOT enumerate test commands per language — that's the
+per-language TDD skill's responsibility. Generic shape:
 
 ```bash
-# Go
-go test ./...                       # all tests
-go test -run TestName ./pkg/core/   # single test
-
-# Flutter
-flutter test                        # all tests
-flutter test test/features/board/   # feature tests
-
-# Python
-pytest tests/ -v                    # all tests
-pytest -k "test_name" -v            # single test
+# <runner> for the project's language
+<runner> [args]                  # all tests
+<runner> [filter] [args]         # single test or pattern
 ```
 
-## Complexity Rule
+Common runners include: `go test`, `flutter test`, `pytest`, `vitest`,
+`bun test`, `cargo test`, etc. The agent must read the project's
+CLAUDE.md or `package.json` / `pyproject.toml` / `go.mod` to learn
+which runner applies before running.
 
-- CC <= 5: Acceptable
-- CC 6-7: Must refactor before commit
-- CC > 7: Blocked by `check-complexity.sh` hook
+## Complexity Rule (universal)
 
-## Write Tests Before Implementation
+- CC ≤ 5: Acceptable.
+- CC 6-7: Must refactor before commit.
+- CC > 7: Blocked by `check-complexity.sh` hook.
 
-Per CLAUDE.md: before implementing any new behavior or bug fix, write tests
-for it first. This applies to all production code in `cmd/`, `pkg/`,
-`flutter_app/lib/`, and `scripts/`.
+## Write Tests Before Implementation (universal)
+
+Per CLAUDE.md (project): before implementing any new behavior or bug
+fix, write tests for it first. This applies to all production code
+in whatever directories the project's CLAUDE.md declares as
+"production code roots" (commonly `cmd/`, `pkg/`, `src/`, `tirvi/`,
+`flutter_app/lib/`, `lib/`, `scripts/`, etc. — varies per project).
+
+The agent **must inspect the project's actual layout** (via
+`Glob`, `ls`, or by reading the project's CLAUDE.md) before
+declaring a path as a production code root. Pattern-matching from
+the harness — "this looks like a project that has a Flutter app"
+— has caused real design errors. See
+`docs/research/sdlc-shortcut-postmortem-phase0.md §lesson 5`.

--- a/.claude/skills/ddd-7l-scaffold/references/README.md
+++ b/.claude/skills/ddd-7l-scaffold/references/README.md
@@ -38,11 +38,27 @@ form for that language. Sections in order:
 4. Include both the "scaffold" code (what to write) and the "anti-pattern" code (what NOT to write)
 5. Reference the project's actual package/folder conventions if known; otherwise generic conventions
 
-## Notes for tirvi specifically
+## How the agent picks a reference for the hosting project
 
-- Production code lives under `tirvi/` (not `pkg/`/`internal/` despite Go conventions in some repos)
-- Tests live under `tests/unit/`, `tests/integration/`, `tests/e2e/`
-- Flutter app under `flutter_app/lib/`; Flutter tests under `flutter_app/test/`
-- No Go code in tirvi today (despite repo conventions allowing it) — `go.md` exists for portability to other projects
+**The harness is project-agnostic.** It does NOT know which language(s)
+the hosting project uses, and the agent must NOT assume one based on
+the references that happen to exist in this folder.
 
-The agent runs L1 inspection first to confirm actual paths before writing.
+The right inspection order:
+
+1. Read the project's `CLAUDE.md` "Project Conventions" / "Stack"
+   section — the project declares its languages and code roots.
+2. Run `ls` / `Glob` against the project root to confirm what code
+   actually exists. Look for `package.json`, `pyproject.toml`,
+   `go.mod`, `pubspec.yaml`, `Cargo.toml`, etc. as language signals.
+3. Pick the matching reference file from this folder. If the
+   project uses a language not represented here, follow "Adding a
+   new language" above.
+4. **Do NOT proceed past L1 until you've confirmed the actual code
+   roots and test roots from the project's repo.** Pattern-matching
+   from "this folder has a `dart.md`" to "this project has a Flutter
+   app" has caused real design errors — see
+   `docs/research/sdlc-shortcut-postmortem-phase0.md §lesson 5`.
+
+The agent runs L1 inspection first to confirm actual paths before
+writing any L2+ artifact.

--- a/docs/research/sdlc-shortcut-postmortem-phase0.md
+++ b/docs/research/sdlc-shortcut-postmortem-phase0.md
@@ -142,11 +142,58 @@ review.
    the design ceremony was reduced, file the postmortem honestly
    and tighten the rule. Don't pantomime the missing rounds against
    shipped code.
+5. **Harness-meta drift is a real failure mode.** Discovered after
+   the F39 backfill landed: F39's design artifacts referenced
+   `flutter_app/lib/components/player/*.dart` with Riverpod —
+   completely wrong stack. The actual player is **vanilla JS +
+   vitest**, mandated by ADR-023, with F33/F35/F36 already shipped
+   in that stack. The harness rules `coding-standards.md` and
+   `tdd-rules.md`, plus `.claude/skills/ddd-7l-scaffold/references/
+   README.md` all carried Flutter/Dart-specific assumptions
+   (e.g., `flutter_app/lib/**/*.dart` paths in frontmatter,
+   "Flutter app under `flutter_app/lib/`" in the references README)
+   that pattern-matched onto F39 even though the project doesn't
+   use Flutter. The error compounded: long context + harness rules
+   that conflated "tooling exists" with "project uses tooling" →
+   F39 design referenced fictional `.dart` files that the workflow
+   ceremony was supposed to catch but didn't.
+
+   **Corrective actions taken in PR #37**:
+
+   - `.claude/rules/coding-standards.md` — restructured into
+     "Universal Rules" (apply to every project, every language) +
+     "Per-language sections" (templates the agent reads ONLY when
+     the hosting project's CLAUDE.md declares the language as in
+     use). Frontmatter `paths:` removed (project-set, not
+     harness-set). Added `### TypeScript / JavaScript` section
+     since most browser-side projects need it.
+   - `.claude/rules/tdd-rules.md` — abstracted the TDD entry-point
+     to "the router detects language from the task's test_file
+     path and the project's CLAUDE.md, then delegates to the
+     matching per-language TDD skill". Removed the hard-coded
+     "@tdd-go or @tdd-flutter" delegation. Three-agent role
+     separation stays as a universal pattern; per-language path
+     matrices live in the corresponding TDD skill's SKILL.md, not
+     in this rule.
+   - `.claude/skills/ddd-7l-scaffold/references/README.md` —
+     removed the "Notes for tirvi specifically" section that
+     incorrectly claimed tirvi has `flutter_app/lib/`. Replaced
+     with a "How the agent picks a reference" section that
+     explicitly mandates project-CLAUDE.md inspection + repo `ls`
+     before assuming any language is in use.
+
+   **The F39 design artifacts themselves still need correction**
+   — they were authored in PR #33 + backfilled in PR #36 against
+   the wrong stack. That correction is its own follow-up PR
+   (out of scope for PR #37), and SHOULD start from a fresh
+   conversation context to avoid re-importing the long-context
+   drift that produced the original error.
 
 ## Sign-off
 
 This document, the workflow.md amendment, and the three backfilled
 artifacts per feature are the explicit closure of the Phase-0 design-
 ceremony gap. PR #36 is the carrier; F53's same-three artifacts
-ride on PR #35. Subsequent feature PRs MUST include all seven
+ride on PR #35. PR #37 follows with the harness-meta corrections
+described in lesson 5. Subsequent feature PRs MUST include all seven
 workitem files at merge time.


### PR DESCRIPTION
## Summary

Closes the harness-meta drift root cause discovered after PR #36 (F39 design backfill) landed. Three harness files were quietly leaking Flutter/Dart assumptions onto every project the harness loaded into, including projects with no Flutter code at all (like tirvi, where ADR-023 binds the player to vanilla JS + vitest).

The leak caused F39's design artifacts to reference fictional `flutter_app/lib/components/player/*.dart` paths with Riverpod state — completely wrong stack. The workflow ceremony was supposed to catch this and didn't, because the harness rules themselves told the agent that Flutter was a project default.

## What changed

### `.claude/rules/coding-standards.md` (universal-first restructure)

- Frontmatter `paths:` (which hardcoded `flutter_app/lib/**/*.dart` etc.) **removed** — paths are a project-level concern, not a harness-level one.
- Restructured into:
  1. **Universal Rules** — CC ≤ 5, tests-first, no secrets, all public APIs documented, format-on-save, type all public surfaces, pure-function preference. These apply to every project and language.
  2. **Project-language declaration** — explicit instruction that the agent MUST inspect the project's CLAUDE.md + repo layout before quoting per-language rules.
  3. **Per-language sections** — Go, Dart/Flutter, Python, **TypeScript / JavaScript** (new), Protobuf — listed as **templates** the agent reads only when the hosting project actually uses the language.

### `.claude/rules/tdd-rules.md` (delegation abstracted)

- Entry-point text abstracted: `/tdd` detects language from the task's `test_file` path + the project's CLAUDE.md, then delegates to the matching per-language TDD skill (e.g., `@tdd-go`, `@tdd-flutter`, `@tdd-python`). Removed the hard-coded "delegates to `@tdd-go` or `@tdd-flutter`" sentence.
- Three-agent role separation kept as a **universal pattern** with a generic table; per-language path matrices live in the corresponding TDD skill's SKILL.md, not in this rule.
- Removed the three hardcoded language-specific tables (Go / Flutter+Dart / Python).
- "Test Commands" section abstracted to common runners (go test / flutter test / pytest / vitest / cargo test / etc.) with explicit instruction to read the project's `package.json` / `pyproject.toml` / `go.mod` first.
- "Write Tests Before Implementation" mandates project-layout inspection before declaring any path as a "production code root".

### `.claude/skills/ddd-7l-scaffold/references/README.md` (the worst-offender lie)

- **"Notes for tirvi specifically"** section REMOVED. It claimed `Flutter app under flutter_app/lib/; Flutter tests under flutter_app/test/` — tirvi has no Flutter code. This was the line that most directly caused F39's stack-mismatch.
- Replaced with **"How the agent picks a reference for the hosting project"** — 4-step inspection order (CLAUDE.md → repo files → matching reference → no proceeding past L1 until paths confirmed) + cross-reference to the postmortem.

### `docs/research/sdlc-shortcut-postmortem-phase0.md`

- Added **lesson #5** documenting the harness-meta drift case study and the corrective actions in this PR.
- Notes that F39's design artifacts themselves still need correction in a follow-up PR, AND that follow-up should start from fresh conversation context — long-context drift was contributing to the original error.

## Test plan

- [x] Full suite: **1024 passed, 92 skipped, 2 xfailed (documented C04/C19), 0 regressions**.
- [x] No production code changes — pure rules + docs.
- [x] Markdown renders cleanly (manual scan).
- [ ] Reviewer to confirm the new "Universal Rules" section preserves every concrete rule that was previously enforced (CC ≤ 5, format-on-save, tests-first, etc.) — none should be silently dropped.
- [ ] Reviewer to confirm the deletion of the tirvi-specific note in `references/README.md` is the right call (the file is a per-language reference template; tirvi-specific notes belong in the project's CLAUDE.md).

## Out of scope (deliberate)

- **F39 design correction.** The artifacts in `.workitems/N04-player/F39-pause-after-question/` (design.md, tasks.md, ontology-delta.yaml, functional-test-plan.md, behavioural-test-plan.md, traceability.yaml) still reference Flutter/Dart paths. They need rewriting against `player/js/` + vitest. That's a follow-up PR; the postmortem says it should start from fresh conversation context.
- **Skill-level descriptions.** `tdd-workflow` skill and similar may still mention Flutter explicitly in their SKILL.md. The harness rules (this PR's scope) are now agnostic; skill-level updates are a separate follow-up.
- **Per-language standards-overlay files.** A project-overlay mechanism (`coding-standards-overlay.md` in the project root) is referenced in the new file but not implemented. If/when a project needs it, that's an additional small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
